### PR TITLE
Update default slurm version to 21.08.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,14 @@
 help:
 	@echo "Usage: make [ help | clean ]"
 
+test:
+	pytest -x -v tests
+
+jekyll:
+	gem install jekyll bundler
+	bundler install
+	bundle exec jekyll serve
+
 clean:
 	git clean -d -f -x
 	# -d: Recurse into directories

--- a/source/cdk/config_schema.py
+++ b/source/cdk/config_schema.py
@@ -58,7 +58,7 @@ config_schema = Schema(
         Optional('HostedZoneId'): str,
         Optional('TimeZone', default='US/Central'): str,
         'slurm': {
-            Optional('SlurmVersion', default='21.08.6'): str,
+            Optional('SlurmVersion', default='21.08.7'): str,
             Optional('ClusterName'): str,
             Optional('MungeKeySsmParameter', default='/slurm/munge_key'): str,
             'SlurmCtl': {


### PR DESCRIPTION
*Issue 3: Update Slurm to version 21.08.7*

Update default Slurm version to 21.08.7.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
