### PR TITLE
Fix FIS spot termination templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Key features are:
 * Multi-cluster federation
 * Manage on-premises compute nodes
 * Configure partitions (queues) and nodes that are always on to support reserved instances RIs and savings plans.
+* AWS Fault Injection Simulator (FIS) templates to test spot terminations
 
 ## Operating System and Processor Architecture Support
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
@@ -11,17 +11,20 @@ cd $repodir
 deactivate &> /dev/null || true
 
 if ! yum list installed make &> /dev/null; then
+    echo -e "\nInstalling make"
     sudo yum -y install make
 fi
 
 if ! yum list installed wget &> /dev/null; then
+    echo -e "\nInstalling wget"
     sudo yum -y install wget
 fi
 
 if ! python3 --version &> /dev/null; then
-    echo "Installing python3"
+    echo -e "\nInstalling python3"
     sudo yum -y install python3
 fi
+
 # Check python version
 python_version=$(python3 --version 2>&1 | awk '{print $2}')
 python_major_version=$(echo $python_version | cut -d '.' -f 1)
@@ -32,7 +35,7 @@ if [[ $python_minor_version -lt 6 ]]; then
 fi
 
 if ! node -v &> /dev/null; then
-    echo "node not found in your path."
+    echo -e "\nnode not found in your path."
     echo "Installing nodejs in your home dir. Hit ctrl-c to abort"
     pushd $HOME
     wget https://nodejs.org/dist/v16.13.1/node-v16.13.1-linux-x64.tar.xz
@@ -61,8 +64,7 @@ if [[ $node_major_version -eq 14 ]] && [[ $node_minor_version -lt 6 ]]; then
 fi
 
 # Create a local installation of cdk
-# If you change the CDK version here, make sure to change it in source/requirements.txt
-CDK_VERSION=2.12.0
+CDK_VERSION=2.21.1 # If you change the CDK version here, make sure to also change it in source/requirements.txt
 if ! cdk --version &> /dev/null; then
     echo "CDK not installed. Installing global version of cdk@$CDK_VERSION."
     sudo npm install -g aws-cdk@$CDK_VERSION

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -1,5 +1,5 @@
 -e .
-aws-cdk-lib==2.12.0
+aws-cdk-lib==2.21.1
 boto3
 colored
 constructs>=10.0.0

--- a/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/SlurmNodeUserData.sh
+++ b/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/SlurmNodeUserData.sh
@@ -102,3 +102,5 @@ ln -s $logs_dir /var/log/slurm
 
 systemctl enable slurmd
 systemctl start slurmd
+# Restart so that log file goes to file system
+systemctl restart spot_monitor

--- a/source/resources/playbooks/roles/install_slurm/tasks/main.yml
+++ b/source/resources/playbooks/roles/install_slurm/tasks/main.yml
@@ -97,7 +97,7 @@
   args:
     creates: "{{SlurmSrcDir}}/slurm-{{SlurmVersion}}/INSTALL"
 
-- name: Build and install slurm on {{distribution}} {{distribution_major_version}}
+- name: Build and install slurm on {{distribution}} {{distribution_major_version}} on {{Architecture}}
   args:
     creates: "{{SlurmBinDir}}/srun"
   shell: |


### PR DESCRIPTION
Add CloudWatch log group

Update CDK to version 2.21.1 to get CfnExperimentTemplate.ExperimentTemplateLogConfigurationProperty

Add filters to FIS templates to only select running or starting instances.

Fix spot monitor bugs.
Cancel a job if it can't be requeued (srun jobs).

Resolves [Issue 7](https://github.com/aws-samples/aws-eda-slurm-cluster/issues/7): AWS Fault Injection Simulator (FIS) templates not working

