### PR TITLE
Add support for FSx for Netapp Ontap

### DIFF
--- a/source/cdk/config_schema.py
+++ b/source/cdk/config_schema.py
@@ -165,10 +165,10 @@ config_schema = Schema(
             Optional('SlurmUid', default=900): int,
             'storage': {
                 Optional('mount_path'): str,
-                Optional('provider', default='efs'): And(str, lambda s: s in ('efs', 'lustre')),
+                Optional('provider', default='efs'): And(str, lambda s: s in ('efs', 'lustre', 'ontap')),
                 Optional('removal_policy', default='RETAIN'): And(str, lambda s: s in ('DESTROY', 'RETAIN', 'SNAPSHOT')),
                 Optional('kms_key_arn'): str,
-                Optional('efs', default={}): {
+                Optional('efs'): {
                     Optional('enable_automatic_backups', default=False): bool,
                     Optional('lifecycle_policy', default='AFTER_30_DAYS'): And(str, lambda s: s in filesystem_lifecycle_policies),
                     Optional('use_efs_helper', default=False): bool,
@@ -183,6 +183,14 @@ config_schema = Schema(
                     Optional('per_unit_storage_throughput', default=50): int,
                     Optional('storage_capacity', default=1200): int,
                     Optional('storage_type'): And(str, lambda s: s in ('HDD', 'SSD')),
+                },
+                Optional('ontap'): {
+                    Optional('deployment_type', default='SINGLE_AZ_1'): And(str, lambda s: s in ('SINGLE_AZ_1', 'MULTI_AZ_1')),
+                    Optional('storage_capacity', default=1024): And(int, lambda s: s >= 1024 and s <= 196608), # 1024 GiB up to 196,608 GiB (192 TiB)
+                    Optional('iops'): int,
+                    Optional('throughput_capacity', default=128): And(int, lambda s: s in [128, 256, 512, 1024, 2048]),
+                    Optional('tiering_policy', default='AUTO'): And(str, lambda s: s in ('ALL', 'AUTO', 'NONE', 'SNAPSHOT_ONLY')),
+                    Optional('cooling_period', default=31): And(int, lambda s: (s >= 2 and s <= 183)),
                 },
                 Optional('ExtraMounts', default=[]): [
                     {

--- a/source/resources/lambdas/GetOntapSvmDNSName/GetOntapSvmDNSName.py
+++ b/source/resources/lambdas/GetOntapSvmDNSName/GetOntapSvmDNSName.py
@@ -1,0 +1,59 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+'''
+Configure the Ontap file system
+'''
+import cfnresponse
+import boto3
+import logging
+from time import sleep
+
+logging.getLogger().setLevel(logging.INFO)
+
+def lambda_handler(event, context):
+    try:
+        logging.info("event: {}".format(event))
+        requestType = event['RequestType']
+        if requestType == 'Delete':
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, "")
+            return
+
+        properties = event['ResourceProperties']
+        required_properties = ['SvmId']
+        error_message = ""
+        for property in required_properties:
+            try:
+                value = properties[property]
+            except:
+                error_message += "Missing {} property. ".format(property)
+        if error_message:
+            raise KeyError(error_message)
+
+        fsx_client = boto3.client('fsx')
+        response = fsx_client.describe_storage_virtual_machines(StorageVirtualMachineIds=[properties['SvmId']])['StorageVirtualMachines'][0]
+        dns_name = response['Endpoints']['Nfs']['DNSName']
+        logging.info(f"DNSName={dns_name}")
+
+        logging.info('Success')
+
+    except Exception as e:
+        logging.exception(str(e))
+        cfnresponse.send(event, context, cfnresponse.FAILED, {'error': str(e)}, str(e))
+
+    cfnresponse.send(event, context, cfnresponse.SUCCESS, {'DNSName': dns_name}, f"{dns_name}")

--- a/source/resources/lambdas/GetOntapSvmDNSName/cfnresponse.py
+++ b/source/resources/lambdas/GetOntapSvmDNSName/cfnresponse.py
@@ -1,0 +1,1 @@
+../cfnresponse.py

--- a/source/resources/playbooks/roles/install_slurm/tasks/main.yml
+++ b/source/resources/playbooks/roles/install_slurm/tasks/main.yml
@@ -111,6 +111,14 @@
     make install &> slurm-make-install.log
     make install-contrib &> slurm-make-install-contrib.log
 
+- name: Create {{SlurmEtcDir}}
+  file:
+    path: "{{SlurmEtcDir}}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0775
+
 - name: Create {{SlurmOSDir}}/etc
   file:
     state: link


### PR DESCRIPTION
Use FSx for Netap ONTAP for the Slurm file system instead of EFS.

Added a SVM to the Ontap filesystem.
Created a custom resources to get the DNSName attribute of the SVM.
Create a volume that can be mounted.

Resolves [Issue 6(https://github.com/aws-samples/aws-eda-slurm-cluster/issues/6)

