### PR TITLE
Add support for on premises compute nodes

### DIFF
--- a/docs/debug.md
+++ b/docs/debug.md
@@ -99,3 +99,12 @@ systemctl restart slurmctld
 ```
 
 Then reboot the node.
+
+Another cause of this is a hung process on the compute node.
+To clear this out, connect to the slurm controller and mark the node down, resume, and then idle.
+
+```
+scontrol update node NODENAME state=DOWN reason=hung
+scontrol update node NODENAME state=RESUME
+scontrol update node NODENAME state=IDLE
+```

--- a/docs/onprem.md
+++ b/docs/onprem.md
@@ -1,0 +1,142 @@
+# On-Premises Integration
+
+The slurm cluster can also be configured to manage on-premises compute nodes.
+The user must configure the on-premises compute nodes and then give the configuration information.
+
+## On-Premises Network and Compute Nodes
+
+The on-prem network must have a CIDR range that doesn't overlap the Slurm cluster's VPC and the two networks
+need to be connected using VPN or AWS Direct Connect.
+The on-prem firewall must allow ingress and egress from the VPC.
+The ports are used to connect to the file systems, slurm controllers, and allow traffic between virtual desktops and compute nodes.
+
+Local network DNS must have an entry for the slurm controller or have a forwarding rule to the AWS provided DNS in the Slurm VPC.
+
+All of the compute nodes in the cluster, including the on-prem nodes, must have file system mounts that replicate the same directory structure.
+This can involve mounting filesystems across VPN or Direct Connect or synchronizing file systems using tools like rsync or NetApp FlexCache or SnapMirror.
+Performance will dictate the architecture of the file system.
+
+## Slurm Configuration of On-Premises Compute Nodes
+
+The slurm cluster's configuration file allows the configuration of on-premises compute nodes.
+The Slurm cluster will not provision any of the on-prem nodes, network, or firewall, but it will configure
+the cluster's resources to be used by the on-prem nodes.
+All that needs to be configured are the configuration file for the on-prem nodes and the CIDR block.
+
+```
+  InstanceConfig:
+    UseSpot: true
+    DefaultPartition: CentOS_7_x86_64_spot
+    NodesPerInstanceType: 10
+    BaseOsArchitecture:
+      CentOS: {7: [x86_64]}
+    Include:
+      MaxSizeOnly: false
+      InstanceFamilies:
+        - t3
+      InstanceTypes: []
+    Exclude:
+      InstanceFamilies: []
+      InstanceTypes:
+        - '.+\.(micro|nano)'   # Not enough memory
+        - '.*\.metal'
+    OnPremComputeNodes:
+      ConfigFile: 'slurm_nodes_on_prem.conf'
+      CIDR: '10.1.0.0/16'
+```
+
+`slurm_nodes_on_prem.conf`
+
+```
+#
+# ON PREMISES COMPUTE NODES
+#
+# Config file with list of statically provisioned on-premises compute nodes that
+# are managed by this cluster.
+#
+# These nodes must be addressable on the network and firewalls must allow access on all ports
+# required by slurm.
+#
+# The compute nodes must have mounts that mirror the compute cluster including mounting the slurm file system
+# or a mirror of it.
+NodeName=Default State=DOWN
+
+NodeName=onprem-c7-x86-t3-2xl-0 nodeaddr=10.1.138.249       CPUs=4  RealMemory=30512   Feature=c7,CentOS_7_x86_64,x86_64,GHz:2.5                Weight=1
+
+#
+#
+# OnPrem Partition
+#
+# The is the default partition
+#
+PartitionName=onprem Default=YES Nodes=\
+onprem-c7-x86-t3-2xl-0
+```
+
+## Simulating an On-Premises Network Using AWS
+
+Create a new VPC with public and private subnets and NAT gateways.
+To simulate the latency between an AWS region and on-prem you can create the VPC in a different region in your account.
+The CIDR must not overlap with the Slurm VPC.
+
+Create a VPC peering connection to your Slurm VPC and accept the connection in the Slurm VPC.
+Create routes in the private subnets for the CIDR of the peered VPC and route it to the vpc peering connection.
+
+Add the on-prem VPC to the Slurm VPC's Route53 private local zone.
+
+Create a Route53 private hosted zone for the on-prem compute nodes and add it to the onprem VPC and the slurm VPC so that onprem compute nodes
+can be resolved.
+
+Copy the Slurm AMIs to the region of the on-prem VPC.
+Create an instance using the copied AMI.
+Connect to the instance and confirm that the mount points mounted correctly.
+You will probably have to change the DNS names for the file systems to IP addresses.
+I created A records in the Route53 zone for the file systems so that if the IP addresses ever change in the future I can easily update them in one place without having to create a new AMI or updated any instances.
+Create a new AMI from the instance.
+
+Create compute node instances from the new AMI and run the following commands on them get the slurmd daemon running so
+they can join the slurm cluster.
+
+```
+# Instance specific variables
+hostname=onprem-c7-x86-t3-2xl-0
+
+# Domain specific variables
+onprem_domain=onprem.com
+
+source /etc/profile.d/instance_vars.sh
+
+# munge needs to be running before calling scontrol
+/usr/bin/cp /opt/slurm/$ClusterName/config/munge.key /etc/munge/munge.key
+systemctl enable munged
+systemctl start munged
+
+ipaddress=$(hostname -I)
+$SLURM_ROOT/bin/scontrol update nodename=${hostname} nodeaddr=$ipaddress
+
+# Set hostname
+hostname_fqdn=${hostname}.${onprem_domain}
+if [ $(hostname) != $hostname_fqdn ]; then
+    hostnamectl --static set-hostname $hostname_fqdn
+    hostnamectl --pretty set-hostname $hostname
+fi
+
+if [ -e /opt/slurm/${ClusterName}/config/users_groups.json ] && [ -e /opt/slurm/${ClusterName}/bin/create_users_groups.py ]; then
+    /opt/slurm/${ClusterName}/bin/create_users_groups.py -i /opt/slurm/${ClusterName}/config/users_groups.json
+fi
+
+# Create directory for slurmd.log
+logs_dir=/opt/slurm/${ClusterName}/logs/nodes/${hostname}
+if [[ ! -d $logs_dir ]]; then
+    mkdir -p $logs_dir
+fi
+if [[ -e /var/log/slurm ]]; then
+    rm -rf /var/log/slurm
+fi
+ln -s $logs_dir /var/log/slurm
+
+systemctl enable slurmd
+systemctl start slurmd
+# Restart so that log file goes to file system
+systemctl restart spot_monitor
+```

--- a/index.md
+++ b/index.md
@@ -6,6 +6,7 @@
 * [README](docs/index.md)
 * [Deploy the Cluster](docs/deploy.md)
 * [Run Jobs](docs/run_jobs.md)
+* [On-Premises Integration](docs/onprem.md)
 * [SOCA Integration](docs/soca_integration.md)
 * [SLURM AMI Based On FPGA Developer AMI](docs/f1-ami.md)
 * [Federation](docs/federation.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ nav:
   - 'index.md'
   - 'deploy.md'
   - 'run_jobs.md'
+  - 'onprem.md'
   - 'soca_integration.md'
   - 'f1-ami.md'
   - 'federation.md'

--- a/source/cdk/config_schema.py
+++ b/source/cdk/config_schema.py
@@ -146,7 +146,11 @@ config_schema = Schema(
                 Optional('AlwaysOnPartitions', default=[]): [
                     str # Partitionlist
                 ],
-                Optional('ComputeNodeConfigFile', default=''): str
+                Optional('OnPremComputeNodes', default={}): {
+                    'ConfigFile': str,
+                    'CIDR': str,
+                    Optional('Partition', default='onprem'): str,
+                }
             },
             Optional('ElasticSearch'): {
                 Optional('ebs_volume_size', default=20): int,

--- a/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/SlurmPlugin.py
+++ b/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/SlurmPlugin.py
@@ -1630,7 +1630,7 @@ class SlurmPlugin:
                 # Note: This includes a heterogenous mix of nodes with different OSes and
                 # architectures
                 #
-                PartitionName=all Default=NO PriorityTier=10000 Nodes=ALL"""), file=fh)
+                PartitionName=all Default=NO Nodes=ALL"""), file=fh)
 
             if instance_config['AlwaysOnNodes']:
                 print(dedent(f"""\

--- a/source/resources/playbooks/roles/SlurmCtl/tasks/slurm_configuration.yml
+++ b/source/resources/playbooks/roles/SlurmCtl/tasks/slurm_configuration.yml
@@ -64,25 +64,44 @@
     group: root
     mode: 0664
     backup: yes
-  register: slurm_conf_result
 
-- name: Create slurm_nodes.conf
+- name: Create slurm_nodes.conf.new
   when: PrimaryController|bool
   shell:
-    creates: "{{SlurmEtcDir}}/slurm_nodes.conf"
     cmd: |
       set -ex
       cp {{INSTANCE_CONFIG_LOCAL_PATH}} {{INSTANCE_CONFIG_PATH}}
       cd {{SlurmScriptsDir}}
-      if ! ./slurm_ec2_create_node_conf.py --config-file {{INSTANCE_CONFIG_LOCAL_PATH}} -o {{SlurmEtcDir}}/slurm_nodes.conf; then
-          rm -f {{SlurmEtcDir}}/slurm_nodes.conf
+      if ! ./slurm_ec2_create_node_conf.py --config-file {{INSTANCE_CONFIG_LOCAL_PATH}} -o {{SlurmEtcDir}}/slurm_nodes.conf.new; then
+          rm -f {{SlurmEtcDir}}/slurm_nodes.conf.new
           exit 1
       fi
-      chown root:root {{SlurmEtcDir}}/slurm_nodes.conf
-      chmod 0644 {{SlurmEtcDir}}/slurm_nodes.conf
-  register: slurm_nodes_conf_result
   tags:
     - slurm_nodes_conf
+
+- name: Create slurm_nodes.conf
+  when: PrimaryController|bool
+  copy:
+    dest: "{{SlurmEtcDir}}/slurm_nodes.conf"
+    remote_src: yes
+    src:  "{{SlurmEtcDir}}/slurm_nodes.conf.new"
+    owner: root
+    group: root
+    mode: 0644
+    backup: yes
+  register: slurm_nodes_conf_result
+
+- name: Create {{ON_PREM_COMPUTE_NODES_CONFIG_PATH}}
+  when: PrimaryController|bool and ON_PREM_COMPUTE_NODES_CONFIG_LOCAL_PATH and ON_PREM_COMPUTE_NODES_CONFIG_PATH
+  copy:
+    dest: "{{ON_PREM_COMPUTE_NODES_CONFIG_PATH}}"
+    remote_src: yes
+    src:  "{{ON_PREM_COMPUTE_NODES_CONFIG_LOCAL_PATH}}"
+    owner: root
+    group: root
+    mode: 0644
+    backup: yes
+  register: slurm_nodes_on_prem_conf_result
 
 - name: Create slurm_licenses.conf
   when: PrimaryController|bool
@@ -189,7 +208,7 @@
     timeout: 1800 # 30 minutes
 
 - name: Restart slurmctld
-  when: ansible_facts.services['slurmctld.service']['state'] == 'running' and (cgroup_conf_result.changed or slurm_licenses_conf_result.changed or slurm_tres_conf_result.changed or slurm_conf_result.changed or sysconfig_slurmctld_result.changed or slurmctld_service_result.changed)
+  when: ansible_facts.services['slurmctld.service']['state'] == 'running' and (cgroup_conf_result.changed or slurm_licenses_conf_result.changed or slurm_tres_conf_result.changed or slurm_conf_result.changed or slurm_nodes_conf_result.changed or slurm_nodes_on_prem_conf_result.changed or sysconfig_slurmctld_result.changed or slurmctld_service_result.changed)
   systemd:
     name: slurmctld
     enabled: yes

--- a/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/etc/slurm.conf
+++ b/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/etc/slurm.conf
@@ -289,4 +289,7 @@ SuspendTime = 660
 
 include slurm_licenses.conf
 include slurm_nodes.conf
+{% if ON_PREM_COMPUTE_NODES_CONFIG is defined %}
+include {{ON_PREM_COMPUTE_NODES_CONFIG}}
+{% endif %}
 include slurm_tres.conf


### PR DESCRIPTION
Add OnPremComputeNodes to config file.
Provide the config file for the on-prem nodes and the on-prem CIDR block.

This will configure slurm to use the on-prem nodes.
It is up to the user to configure the on-prem compute nodes themselves.

Resolved [Feature Request 1: Support on-prem compute nodes ](https://github.com/aws-samples/aws-eda-slurm-cluster/issues/1)