### PR TITLE
Update slurm to 21.08.8

### DIFF
--- a/source/cdk/config_schema.py
+++ b/source/cdk/config_schema.py
@@ -58,7 +58,7 @@ config_schema = Schema(
         Optional('HostedZoneId'): str,
         Optional('TimeZone', default='US/Central'): str,
         'slurm': {
-            Optional('SlurmVersion', default='21.08.7'): str,
+            Optional('SlurmVersion', default='21.08.8'): str,
             Optional('ClusterName'): str,
             Optional('MungeKeySsmParameter', default='/slurm/munge_key'): str,
             'SlurmCtl': {


### PR DESCRIPTION
Resolve critical security CVEs.

Resolves [Bug # 15](https://github.com/aws-samples/aws-eda-slurm-cluster/issues/15)

*Issue #, if available:*

*Description of changes:*

Update the default slurm version in the config schema.

The older versions of slurm with the CVEs are no longer available for download so new stacks will fail until this is merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
