### PR TITLE
Allow slurm controller to create spot service linked role

### DIFF
--- a/source/cdk/cdk_slurm_stack.py
+++ b/source/cdk/cdk_slurm_stack.py
@@ -1698,6 +1698,15 @@ class CdkSlurmStack(Stack):
                 iam.PolicyStatement(
                     effect = iam.Effect.ALLOW,
                     actions = [
+                        'iam:CreateServiceLinkedRole',
+                    ],
+                    resources = [
+                        '*'
+                    ]
+                ),
+                iam.PolicyStatement(
+                    effect = iam.Effect.ALLOW,
+                    actions = [
                         'iam:PassRole'
                     ],
                     resources = [


### PR DESCRIPTION
This is required so that spot instances can be launched.

Resolves [Bug #23](https://github.com/aws-samples/aws-eda-slurm-cluster/issues/23)

*Description of changes:*
Add iam:CreateServiceLinkedRole permission to slurm controllers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
