### PR TITLE
Move AMI instances from public subnet to slurm subnet

### DIFF
--- a/source/cdk/cdk_slurm_stack.py
+++ b/source/cdk/cdk_slurm_stack.py
@@ -2268,7 +2268,7 @@ class CdkSlurmStack(Stack):
                         instance_type=ec2.InstanceType(self.config['slurm']['SlurmNodeAmis']['instance_type'][architecture]),
                         key_name=self.config['SshKeyPair'],
                         vpc=self.vpc,
-                        vpc_subnets = ec2.SubnetSelection(subnet_type=ec2.SubnetType.PUBLIC),
+                        vpc_subnets = ec2.SubnetSelection(subnets=[self.subnet]),
                         block_devices = block_devices,
                         role=self.slurm_node_ami_role,
                         security_group=self.slurmnode_sg,


### PR DESCRIPTION
Use the same subnet as the other slurm instances.

Resolves [Bug #26](https://github.com/aws-samples/aws-eda-slurm-cluster/issues/26)
