### PR TITLE
Disable selinux across reboots

### DIFF
--- a/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/SlurmNodeUserData.sh
+++ b/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/SlurmNodeUserData.sh
@@ -100,6 +100,10 @@ if [[ -e /var/log/slurm ]]; then
 fi
 ln -s $logs_dir /var/log/slurm
 
+# Selinux must be disable for slurmd to run
+setenforce Permissive
+sed -i 's/^SELINUX=.*/SELINUX=disabled/' /etc/sysconfig/selinux
+
 systemctl enable slurmd
 systemctl start slurmd
 # Restart so that log file goes to file system

--- a/source/resources/playbooks/roles/all/tasks/main.yml
+++ b/source/resources/playbooks/roles/all/tasks/main.yml
@@ -106,6 +106,7 @@
   shell:
     cmd: |
       setenforce Permissive
+      sed -i 's/^SELINUX=.*/SELINUX=disabled/' /etc/sysconfig/selinux
 
 # Used by mount_ssds.bash
 - name: Install packages required by mount_ssds.bash


### PR DESCRIPTION
Selinux breaks the slurmd service and must be disabled.

Resolves #34.

*Description of changes:*

Update /etc/sysconfig/selinux

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
