### PR TITLE
Remove per-boot userdata for ami node from compute node ami.

### DIFF
--- a/source/cdk/cdk_slurm_stack.py
+++ b/source/cdk/cdk_slurm_stack.py
@@ -2485,6 +2485,11 @@ class CdkSlurmStack(Stack):
                     instance_template_vars['RemoteComputeRegions'] = ','.join(self.remote_compute_regions.keys())
                     instance_template_vars['SLURM_ROOT'] = f"{instance_template_vars['FileSystemMountPath']}/slurm-{self.config['slurm']['SlurmVersion']}/{distribution}/{distribution_major_version}/{architecture}"
 
+                    # Check to make sure running on the AMI node
+                    user_data = open("resources/user_data/slurm_node_ami_user_data_prolog.sh", 'r').read()
+                    print(f"user_data:\n{user_data}")
+                    self.slurm_node_ami_instance.user_data.add_commands(user_data)
+
                     # Add on_exit commands at top of user_data
                     self.slurm_node_ami_instance.user_data.add_signal_on_exit_command(self.slurm_node_ami_instance)
                     on_exit_commands_template = Template(open("resources/user_data/slurm_node_ami_user_data_on_exit.sh", 'r').read())

--- a/source/resources/config/ami_map.yml
+++ b/source/resources/config/ami_map.yml
@@ -3,18 +3,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-045af2dbb2a6105a0 # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-0c9b903eaf332af4c # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-004daf3add9941dbf # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-0113c5fc6ac5e0043 # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-07b3b0525cef50a4a # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-03361228a16aabbea # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-06ce6680729711877 # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-059755f6af2e54b66 # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:
@@ -55,18 +55,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-073e739d5c35a2668 # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-066449bb2eec0a5a3 # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-09e6b7a3b88bc9889 # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-0b808e3ad34cb9737 # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-0008c5e405a3b3013 # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-07071aa2caa3d64c8 # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-0e1d09d8b7c751816 # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-0633fb238d7de0f95 # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:
@@ -107,15 +107,15 @@ AmiMap:
     AlmaLinux:
       8:
         x86_64:
-          ImageId: ami-01184a80d649091d8 # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-0848a81cb13386a65 # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-011fa3a3b2ec9941a # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-0a3a798c4ad8fe477 # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-0253beba286f3e848 # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-03dc2e74e9f2c4663 # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     RedHat:
       7:
@@ -141,18 +141,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-0e2e72f3a693aebcf # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-0b33eff7b67344b82 # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-03d32b33fd993411b # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-0d0a3f206d0bd1efc # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-044ba583062cb113b # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-0dc741c55a1bd33ce # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-09de362f44ba0a166 # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-00c5a35740f4561e7 # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:
@@ -193,18 +193,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-003ea4f1745f43adc # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-0e50cda203faa584e # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-03292af505f184a36 # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-0226c7236bc5c777b # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-0b9800433ca2a0b20 # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-0098dd09f8818784f # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-0adf622550366ea53 # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-073f0a6c667dfeecf # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:
@@ -245,18 +245,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-00827942abed189f4 # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-0dee75b996ea93e4f # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-04ce4552e468d870d # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-0beacb82191c7b2d9 # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-0eb411a778563ea89 # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-07466c8ac1a23262d # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-03b836d87d294e89e # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-016768a42b53f657a # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:
@@ -297,18 +297,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-088b1d9b34c4fe329 # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-0c73f239392029939 # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-03f9f1c20c7f168e3 # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-02babadf9c5e63d47 # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-058c397e06e2c3b81 # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-0576ee2a03be65a68 # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-04c12937e87474def # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-0bafcea81f5e35831 # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:
@@ -349,18 +349,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-0dd0df0d8fda81403 # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-0adb3f744482a3849 # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-09fb665bbc486902e # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-049e79e8a8e13327c # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-08600ae8f3553d244 # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-004e02654d9016738 # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-094c442a8e9a67935 # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-02cf11196cf0818e8 # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:
@@ -401,18 +401,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-01e414da9ba8092a3 # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-04edfa9ff60193e21 # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-01d058a3ef74c3366 # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-05d343ed0beb6c1eb # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-012b607981f0a40bd # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-02177b37c1a913406 # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-04e8b0e36ed3403dc # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-03b26f0b11774cf30 # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:
@@ -453,18 +453,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-05f379012b69a05e8 # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-0272e5d6e63653845 # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-02ab0126115dd05cf # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-07715cd6db772c7e3 # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-06b4c3e5d2605128e # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-06cecbaef31457ce9 # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-0bba0a4cb75835f71 # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-0be9259c3f48b4026 # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:
@@ -508,18 +508,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-060537915d4508a11 # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-0b840f2c87f66b1cb # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-0ce15bfb496be9059 # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-0625af50d3384aff2 # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-0f2913dd376f23830 # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-07bdb6c65efe05854 # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-030770b178fa9d374 # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-001c1821bbfc6dfd5 # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:
@@ -560,18 +560,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-0d8fedb7071cdf4d3 # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-009578ad888857a55 # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-0ffcfdfd70c0762ec # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-05772b392a34b94b8 # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-07a985aa4099754db # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-04a1596379e1536c4 # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-0614433a16ab15878 # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-06033c5e25038a317 # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:
@@ -612,18 +612,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-00e9419fa2ade1612 # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-0bbf4ed8f61e3dec6 # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-012bb194cdf068648 # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-0bf9c7cf3f259cdbc # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-0bacea481e0d399f9 # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-051893550f75bfa43 # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-0656df2cc0dfd150a # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-01bb4acf3a0069f87 # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:
@@ -664,18 +664,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-0dd1ccd3f90119a82 # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-07c63d26f68b4ebff # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-00cf249161bc21a71 # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-013e93e9fbc908d88 # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-09f0bb50202ca06b0 # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-0201c8df31f1b7ead # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-065efef2c739d613b # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-0cabc39acf991f4f1 # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:
@@ -719,18 +719,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-034b3e2afab4de9e5 # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-0d52725c4d40770b9 # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-0c1fbef3b864e6e95 # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-0c520b629d071105a # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-093dde316d91535f5 # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-0aca53792a35df478 # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-07251f912d2a831a3 # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-017a73c6475f1cefe # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:
@@ -749,9 +749,6 @@ AmiMap:
           RootDeviceName: /dev/sda1
     RedHat:
       7:
-        arm64:
-          ImageId: ami-0302c1ecc74930ba5 # RHEL-7.6_HVM_GA-20181122-arm64-0-Hourly2-GP2
-          RootDeviceName: /dev/sda1
         x86_64:
           ImageId: ami-0d2bf41df19c4aac7 # RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2
           RootDeviceName: /dev/sda1
@@ -774,18 +771,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-02d409b077709fb8b # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-0147ff11336f31d0c # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-022c799ffdedfc05b # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-0e046a5d1172cba32 # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-023670b6c7f24006a # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-02f326917b1b175da # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-09b2f6d85764ec71b # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-0d1ac128cb656dd42 # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:
@@ -826,18 +823,18 @@ AmiMap:
     AlmaLinux:
       8:
         arm64:
-          ImageId: ami-00d576428396b000f # AlmaLinux OS 8.6.20220513 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
+          ImageId: ami-0f2aa0306aa17406b # AlmaLinux OS 8.6.20220715 aarch64-744775f7-4efd-4c75-ac32-eb2540b4030c
           RootDeviceName: /dev/sda1
         x86_64:
-          ImageId: ami-05bb52bb5937accfe # AlmaLinux OS 8.6.20220513 x86_64-c076b20a-2305-4771-823f-944909847a05
+          ImageId: ami-01ad1e3d2d7278f10 # AlmaLinux OS 8.6.20220715 x86_64-c076b20a-2305-4771-823f-944909847a05
           RootDeviceName: /dev/sda1
     Amazon:
       2:
         arm64:
-          ImageId: ami-0d3c51ccaa76cbe2b # amzn2-ami-hvm-2.0.20220606.1-arm64-gp2
+          ImageId: ami-0e052983952750fca # amzn2-ami-hvm-2.0.20220719.0-arm64-gp2
           RootDeviceName: /dev/xvda
         x86_64:
-          ImageId: ami-0d08ef957f0e4722b # amzn2-ami-hvm-2.0.20220606.1-x86_64-gp2
+          ImageId: ami-0c43067304fd16596 # amzn2-ami-hvm-2.0.20220719.0-x86_64-gp2
           RootDeviceName: /dev/xvda
     CentOS:
       7:

--- a/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/SlurmPlugin.py
+++ b/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/SlurmPlugin.py
@@ -778,6 +778,7 @@ class SlurmPlugin:
                                 {'Key': 'ClusterName', 'Value': self.config['ClusterName']},
                                 {'Key': 'hostname', 'Value': hostname},
                                 {'Key': 'role', 'Value': 'SlurmNode'},
+                                {'Key': 'NodeType', 'Value': 'SlurmNode'},
                                 {'Key': 'distribution', 'Value': hostinfo['distribution']},
                                 {'Key': 'distribution_major_version', 'Value': hostinfo['distribution_major_version']},
                                 {'Key': 'spot', 'Value': str(hostinfo['spot'])},

--- a/source/resources/user_data/slurm_node_ami_config.sh
+++ b/source/resources/user_data/slurm_node_ami_config.sh
@@ -40,7 +40,7 @@ fi
 # Install security updates first.
 # Since this is Amazon Linux 2 don't need to configure proxy because yum repos are in S3.
 # Disable epel because it isn't in S3 and requires configuration.
-yum -y update --security --bugfix
+yum -y update --security --bugfix || true
 
 export PATH=/usr/local/bin:$PATH
 

--- a/source/resources/user_data/slurm_node_ami_user_data.sh
+++ b/source/resources/user_data/slurm_node_ami_user_data.sh
@@ -3,15 +3,12 @@
 
 # The environment variables are set before this part of the user_data runs.
 
-# Rerun after reboot
 script=$(readlink -f $0)
 script_name=$(basename $script)
-rerun_script=/var/lib/cloud/scripts/per-boot/10_$script_name
-ln -sf $script $rerun_script
 
 # Tag EBS disks manually
-AWS_AVAIL_ZONE=$(curl http://169.254.169.254/latest/meta-data/placement/availability-zone)
-AWS_INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
+AWS_AVAIL_ZONE=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
+AWS_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 EBS_IDS=$(aws ec2 describe-volumes --filters Name=attachment.instance-id,Values="$AWS_INSTANCE_ID" --region $AWS_DEFAULT_REGION --query "Volumes[*].[VolumeId]" --out text | tr "\n" " ")
 aws ec2 create-tags --resources $EBS_IDS --region $AWS_DEFAULT_REGION --tags Key=Name,Value="${STACK_NAME} SlurmNodeAMI Root Disk"
 

--- a/source/resources/user_data/slurm_node_ami_user_data_prolog.sh
+++ b/source/resources/user_data/slurm_node_ami_user_data_prolog.sh
@@ -1,0 +1,24 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# This is the first thing to run in the user_data
+
+script=$(readlink -f $0)
+script_name=$(basename $script)
+
+# Rerun after reboot
+# We want the user_data to be run every time the instance boots so that all of the latest S3 assets and other configuration is downloaded.
+# But this is only for the AMI instances.
+# Check the "role" tag and delete the rerun script if not "slurm_node_ami"
+old_rerun_script=/var/lib/cloud/scripts/per-boot/10_user_data
+rm -f $old_rerun_script
+rerun_script=/var/lib/cloud/scripts/per-boot/10_slurm_node_ami_user_data
+AWS_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+node_type=$(aws ec2 describe-tags --filters '[{"Name":"resource-id","Values":["'$AWS_INSTANCE_ID'"]},{"Name":"tag:NodeType","Values":["*"]}]' --query 'Tags[0].Value' --output text)
+if [[ $node_type == 'slurm_node_ami' ]]; then
+    ln -sf $script $rerun_script
+else
+    trap - EXIT
+    rm -f $rerun_script
+    exit 0
+fi

--- a/source/resources/user_data/slurmctl_config.sh
+++ b/source/resources/user_data/slurmctl_config.sh
@@ -22,7 +22,7 @@ trap on_exit EXIT
 # Install security updates first.
 # Since this is Amazon Linux 2 don't need to configure proxy because yum repos are in S3.
 # Disable epel because it isn't in S3 and requires configuration.
-yum -y update --security --bugfix
+yum -y update --security --bugfix || true
 
 # Update to latest ssm agent
 if yum install -y https://s3.$AWS_DEFAULT_REGION.amazonaws.com/amazon-ssm-$AWS_DEFAULT_REGION/latest/linux_amd64/amazon-ssm-agent.rpm; then

--- a/source/resources/user_data/slurmdbd_config.sh
+++ b/source/resources/user_data/slurmdbd_config.sh
@@ -22,7 +22,7 @@ trap on_exit EXIT
 # Install security updates first.
 # Since this is Amazon Linux 2 don't need to configure proxy because yum repos are in S3.
 # Disable epel because it isn't in S3 and requires configuration.
-yum -y update --security --bugfix
+yum -y update --security --bugfix || true
 
 # Update to latest ssm agent
 if yum install -y https://s3.$AWS_DEFAULT_REGION.amazonaws.com/amazon-ssm-$AWS_DEFAULT_REGION/latest/linux_amd64/amazon-ssm-agent.rpm; then


### PR DESCRIPTION
It gets saved in the AMI so check for the NodeType tag and remove it if not running on a slurm_nod_ami.
    
Resolves #39.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
