### PR TITLE
Fix syntax error in slurm_ec2_resume_fail.py

### DIFF
--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -59,8 +59,8 @@ to a node with a different instance type or it will fail.
 This can take a substantial amount of time so `SlurmPlugin.py` does the following when it receives an ICE.
 
 * Mark the node as DRAIN so no new jobs are scheduled on it.
-* Find all other nodes of the same type and mark them DOWN so that they won't be scheduled after this node is marked DOWN. Nodes that are running will be left alone.
+* Find all other powered down nodes of the same type and mark them DOWN so that they won't be scheduled after this node is marked DOWN. Nodes that are running will be left alone.
 * Requeue jobs on the node that failed to resume because of ICE.
 * Mark the node DOWN.
 * Power down the node. This is so that Slurm knows that the node is powered down so that when it is marked IDLE it will be powered up when a job is scheduled on it.
-* A cron job periodically finds all DOWN Slurm nodes, powers them down, and then marks them IDLE so that they can have jobs scheduled on them. This will allow Slurm to attempt to use more nodes of the instance type in the hopes that there is more capacity. If not, then the cycle repeats.
+* The `slurm_down_nodes_clean.service` periodically finds all DOWN Slurm nodes, powers them down, and then marks them IDLE so that they can have jobs scheduled on them. This will allow Slurm to attempt to use more nodes of the instance type in the hopes that there is more capacity. If not, then the cycle repeats.

--- a/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/slurm_ec2_publish_cw.py
+++ b/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/slurm_ec2_publish_cw.py
@@ -19,7 +19,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import logging
 from SlurmPlugin import SlurmPlugin
-from sys import exit
+from sys import argv, exit
 
 logger = logging.getLogger(__file__)
 logger_formatter = logging.Formatter('%(levelname)s:%(asctime)s: %(message)s')
@@ -31,9 +31,13 @@ logger.setLevel(logging.INFO)
 if __name__ == '__main__':
     rc = 1
     try:
+        logger.info("====================================================================================================")
+        logger.info(f"{__file__} {argv[1:]}")
+        logger.info("====================================================================================================")
         plugin = SlurmPlugin()
         rc = plugin.publish_cw()
     except:
         logging.exception(f"Unhandled exception in {__file__}")
-        raise
+        plugin.publish_cw_metrics(plugin.CW_UNHANDLED_PUBLISH_CW_METRICS_EXCEPTION, 1, [])
+        rc = 1
     exit(rc)

--- a/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/slurm_ec2_resume.py
+++ b/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/slurm_ec2_resume.py
@@ -19,6 +19,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import logging
 from SlurmPlugin import SlurmPlugin
+from sys import argv, exit
 
 logger = logging.getLogger(__file__)
 logger_formatter = logging.Formatter('%(levelname)s:%(asctime)s: %(message)s')
@@ -29,8 +30,13 @@ logger.setLevel(logging.INFO)
 
 if __name__ == '__main__':
     try:
+        logger.info("====================================================================================================")
+        logger.info(f"{__file__} {argv[1:]}")
+        logger.info("====================================================================================================")
         plugin = SlurmPlugin()
-        plugin.resume()
+        rc = plugin.resume()
     except:
         logging.exception(f"Unhandled exception in {__file__}")
-        raise
+        plugin.publish_cw_metrics(plugin.CW_UNHANDLED_RESUME_EXCEPTION, 1, [])
+        rc = 1
+    exit(rc)

--- a/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/slurm_ec2_resume_fail.py
+++ b/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/slurm_ec2_resume_fail.py
@@ -19,6 +19,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import logging
 from SlurmPlugin import SlurmPlugin
+from sys import argv, exit
 
 logger = logging.getLogger(__file__)
 logger_formatter = logging.Formatter('%(levelname)s:%(asctime)s: %(message)s')
@@ -28,9 +29,15 @@ logger.addHandler(logger_rotatingFileHandler)
 logger.setLevel(logging.INFO)
 
 if __name__ == '__main__':
+    rc = 1
     try:
+        logger.info("====================================================================================================")
+        logger.info(f"{__file__} {argv[1:]}")
+        logger.info("====================================================================================================")
         plugin = SlurmPlugin()
-        plugin.resume_fail()
+        rc = plugin.resume_fail()
     except:
         logging.exception(f"Unhandled exception in {__file__}")
-        raise
+        plugin.publish_cw_metrics(plugin.CW_UNHANDLED_RESUME_FAIL_EXCEPTION, 1, [])
+        rc = 1
+    exit(rc)

--- a/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/slurm_ec2_stop.py
+++ b/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/slurm_ec2_stop.py
@@ -19,6 +19,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import logging
 from SlurmPlugin import SlurmPlugin
+from sys import argv, exit
 
 logger = logging.getLogger(__file__)
 logger_formatter = logging.Formatter('%(levelname)s:%(asctime)s: %(message)s')
@@ -29,8 +30,13 @@ logger.setLevel(logging.INFO)
 
 if __name__ == '__main__':
     try:
+        logger.info("====================================================================================================")
+        logger.info(f"{__file__} {argv[1:]}")
+        logger.info("====================================================================================================")
         plugin = SlurmPlugin()
-        plugin.stop()
+        rc = plugin.stop()
     except:
         logging.exception(f"Unhandled exception in {__file__}")
-        raise
+        plugin.publish_cw_metrics(plugin.CW_UNHANDLED_STOP_EXCEPTION, 1, [])
+        rc = 1
+    exit(rc)

--- a/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/slurm_ec2_terminate.py
+++ b/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/slurm_ec2_terminate.py
@@ -19,6 +19,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import logging
 from SlurmPlugin import SlurmPlugin
+from sys import argv, exit
 
 logger = logging.getLogger(__file__)
 logger_formatter = logging.Formatter('%(levelname)s:%(asctime)s: %(message)s')
@@ -29,8 +30,13 @@ logger.setLevel(logging.INFO)
 
 if __name__ == '__main__':
     try:
+        logger.info("====================================================================================================")
+        logger.info(f"{__file__} {argv[1:]}")
+        logger.info("====================================================================================================")
         plugin = SlurmPlugin()
-        plugin.terminate()
+        rc = plugin.terminate()
     except:
         logging.exception(f"Unhandled exception in {__file__}")
-        raise
+        plugin.publish_cw_metrics(plugin.CW_UNHANDLED_TERMINATE_EXCEPTION, 1, [])
+        rc = 1
+    exit(rc)

--- a/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/terminate_old_instances.py
+++ b/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/terminate_old_instances.py
@@ -19,7 +19,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import logging
 from SlurmPlugin import SlurmPlugin
-from sys import exit
+from sys import argv, exit
 
 logger = logging.getLogger(__file__)
 logger_formatter = logging.Formatter('%(levelname)s:%(asctime)s: %(message)s')
@@ -31,9 +31,13 @@ logger.setLevel(logging.INFO)
 if __name__ == '__main__':
     rc = 1
     try:
+        logger.info("====================================================================================================")
+        logger.info(f"{__file__} {argv[1:]}")
+        logger.info("====================================================================================================")
         plugin = SlurmPlugin()
         rc = plugin.terminate_old_instances_main()
     except:
         logger.exception(f"Unhandled exception in {__file__}")
-        raise
+        plugin.publish_cw_metrics(plugin.CW_UNHANDLED_TERMINATE_OLD_INSTANCES_EXCEPTION, 1, [])
+        rc = 1
     exit(rc)

--- a/source/resources/playbooks/roles/all/tasks/main.yml
+++ b/source/resources/playbooks/roles/all/tasks/main.yml
@@ -105,8 +105,10 @@
   when: rhel8 or rhel8clone
   shell:
     cmd: |
+      set -ex
       setenforce Permissive
       sed -i 's/^SELINUX=.*/SELINUX=disabled/' /etc/sysconfig/selinux
+      sed -i 's/^SELINUX=.*/SELINUX=disabled/' /etc/selinux/config
 
 # Used by mount_ssds.bash
 - name: Install packages required by mount_ssds.bash


### PR DESCRIPTION
The main function was requiring an unused region parameter that wasn't being passed.

Add better error handling to the calling scripts.

Update documentation of how ICE is handled

Fix disabling selinux for redhat 8 family

Resolves #54

Resolves #55

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
