### PR TITLE
Handle case where SubnetId is not specified or is invalid

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -83,7 +83,9 @@ fi
 version=$(cdk --version | awk '{print $1}')
 if [[ $version != $CDK_VERSION ]]; then
     echo "Updating the global version of aws-cdk from version $version to $CDK_VERSION"
+    echo "Uninstalling old version: npm uninstall -g aws-cdk"
     npm uninstall -g aws-cdk
+    echo "npm install -g aws-cdk@$CDK_VERSION"
     if ! npm install -g aws-cdk@$CDK_VERSION; then
         sudo npm install -g aws-cdk@$CDK_VERSION
     fi

--- a/source/cdk/config_schema.py
+++ b/source/cdk/config_schema.py
@@ -298,7 +298,7 @@ config_schema = Schema(
                     Optional('InstanceFamilies', default=default_eda_instance_families): [str],
                     Optional('InstanceTypes', default=default_eda_instance_types): [str]
                 },
-                Optional('Regions', default={}): {
+                Optional('Regions'): {
                     str: {
                         'VpcId': And(str, lambda s: re.match('vpc-', s)),
                         'CIDR': str,


### PR DESCRIPTION
I hadn't tested the case where SubnetId isn't in the config file. Had to move the SubnetId specific configuration after the creation of the VPC object so could get the private subnets so I can choose a default subnet from the list.

Added a check and error if the VPC doesn't have any private subnets.

Resolves #61

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
