### PR TITLE
Add SchedulerParameters=bf_licenses

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,7 @@ if [[ $node_major_version -eq 14 ]] && [[ $node_minor_version -lt 6 ]]; then
 fi
 
 # Create a local installation of cdk
-CDK_VERSION=2.28.1 # If you change the CDK version here, make sure to also change it in source/requirements.txt
+CDK_VERSION=2.46.0 # If you change the CDK version here, make sure to also change it in source/requirements.txt
 if ! cdk --version &> /dev/null; then
     echo "CDK not installed. Installing global version of cdk@$CDK_VERSION."
     if ! npm install -g aws-cdk@$CDK_VERSION; then

--- a/source/cdk/cdk_slurm_stack.py
+++ b/source/cdk/cdk_slurm_stack.py
@@ -107,13 +107,14 @@ class CdkSlurmStack(Stack):
 
         self.check_config()
 
-        # Assets must be created before setting instance_template_vars so the playbooks URL exists
-        self.create_assets()
-
         # Create VPC before lambdas so that lambdas can access the VPC.
         self.create_vpc()
 
         self.check_regions_config()
+
+        # Must be called after check_regions_config so that 'Regions' is set in the InstanceConfig.
+        # Assets must be created before setting instance_template_vars so the playbooks URL exists
+        self.create_assets()
 
         self.create_remote_vpcs()
 

--- a/source/cdk/config_schema.py
+++ b/source/cdk/config_schema.py
@@ -261,6 +261,8 @@ config_schema = Schema(
             # SubmitterSecurityGroupIds:
             #     External security groups that should be able to use the cluster
             Optional('SubmitterSecurityGroupIds'): {str: str},
+            # SubmitterInstanceTags:
+            #    Tags of instances configure to submit to the cluster. When the cluster is deleted the tag is used unmount the slurm filesystem from the instannces using SSM.
             Optional('SubmitterInstanceTags'): {str: [str]},
             #
             # InstanceConfig:

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -1,5 +1,5 @@
 -e .
-aws-cdk-lib==2.28.1
+aws-cdk-lib==2.46.0
 boto3
 colored
 constructs>=10.0.0

--- a/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/etc/slurm.conf
+++ b/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/etc/slurm.conf
@@ -96,6 +96,9 @@ SchedulerType=sched/backfill
 #     from its original job list after releasing locks even if job or node state changes
 # bf_interval: The number of seconds between backfill iterations. Higher values
 #     result in less overhead and better responsiveness.
+# bf_licenses: Require the backfill scheduling logic to track and plan for license availability.
+#     By default, any job blocked on license availability will not have resources reserved which can lead to job starvation.
+#     This option implicitly enables bf_running_job_reserve.
 # bf_max_job_test: The maximum number of jobs to attempt backfill scheduling for.
 # bf_max_job_user: The maximum number of jobs per user to attempt starting with
 #     the backfill scheduler for ALL partitions. One can set this limit to prevent
@@ -125,6 +128,7 @@ SchedulerParameters=\
 batch_sched_delay=10\
 ,bf_continue\
 ,bf_interval=30\
+,bf_licenses\
 ,bf_max_job_test=500\
 ,bf_max_job_user=0\
 ,bf_yield_interval=1000000\


### PR DESCRIPTION
Update CDK to latest version: 2.46.0.

Fix syntax error in slurm_ec2_create_node_conf.py by writing correct InstanceConfig.yml that has Regions set.

Resolves #60
Resolves #67

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
