### PR TITLE
Add PrologFlags for x11 and cgroups

### DIFF
--- a/docs/run_jobs.md
+++ b/docs/run_jobs.md
@@ -1,12 +1,12 @@
 # Run Jobs
 
-This page is to give some basic instructions on how to run and monitor jobs on SLURM.
-SLURM provides excellent man pages for all of its commands, so if you have questions refer
+This page is to give some basic instructions on how to run and monitor jobs on Slurm.
+Slurm provides excellent man pages for all of its commands, so if you have questions refer
 to the man pages.
 
 ## Set Up
 
-Load the environment module for slurm to configure your PATH and SLURM related environment
+Load the environment module for Slurm to configure your PATH and Slurm related environment
 variables.
 
 ```
@@ -23,9 +23,9 @@ For example, the SQUEUE_FORMAT2 and SQUEUE_SORT environment variables are set so
 the default output format is easier to read and contains useful information that isn't
 in the default format.
 
-## Key SLURM Commands
+## Key Slurm Commands
 
-The key SLURM commands are
+The key Slurm commands are
 
 | Command | Description | Example
 |---------|-------------|---------
@@ -33,7 +33,7 @@ The key SLURM commands are
 | srun    | Run a job within an allocation. | srun --pty bin/bash
 | squeue  | Get job status |
 | scancel | Cancel a job | scancel *jobid*
-| sinfo   | Get info about slurm node status | sinfo -p all
+| sinfo   | Get info about Slurm node status | sinfo -p all
 | scontrol |
 | sstat       | Display various status information about a running job/step
 | sshare      | Tool for listing fair share information
@@ -83,7 +83,7 @@ To open up a pseudo terminal in your shell on a compute node with 4 cores and 16
 srun -c 4 --mem 8G --pty /bin/bash
 ```
 
-This will queue a job and when it is allocated to a node and the node runs the job control will be returned to
+This will queue a job and when it is allocated to a node and the node runs, the job control will be returned to
 your shell, but stdin and stdout will be on the compute node.
 If you set your DISPLAY environment variable and allow external X11 connections you can use this to
 run interactive GUI jobs on the compute node and have the windows on your instance.
@@ -93,6 +93,12 @@ xhost +
 export DISPLAY=$(hostname):$(echo $DISPLAY | cut -d ':' -f 2)
 srun -c 4 --mem 8G --pty /bin/bash
 emacs . # Or whatever gui application you want to run. Should open a window.
+```
+
+Another way to run interactive GUI jobs is to use **srun**'s **--x11** flag to enable X11 forwarding.
+
+```
+srun -c 1 --mem 8G --pty --x11 emacs
 ```
 
 ## squeue
@@ -140,14 +146,14 @@ man sacct
 
 The `sreport` command can be used to generate report from the Slurm database.
 
-## Other SLURM Commands
+## Other Slurm Commands
 
-Use `man command` to get information about these less commonly used SLURM commands.
+Use `man command` to get information about these less commonly used Slurm commands.
 
 | Command     | Description
 |-------------|-------------
 | sacctmgr    | View/modify Slurm account information
-| salloc      | Obtain a slurm job allocation
+| salloc      | Obtain a Slurm job allocation
 | sattach     | Attach to a job step
 | sbcast      | Transmit a file to the nodes allocated to a Slurm job.
 | scrontab    | Manage slurm crontab files

--- a/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/etc/slurm.conf
+++ b/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/etc/slurm.conf
@@ -37,6 +37,24 @@ JobSubmitPlugins=defaults
 LaunchParameters=enable_nss_slurm
 MpiDefault=none
 ProctrackType=proctrack/cgroup
+#
+# PrologFlags:
+# * Alloc: If set, the Prolog script will be executed at job allocation.
+#   By default, Prolog is executed just before the task is launched. Therefore, when
+#   salloc is started, no Prolog is executed. Alloc is useful for preparing things
+#   before a user starts to use any allocated resources. In particular, this flag is
+#   needed on a Cray system when cluster compatibility mode is enabled.
+#   NOTE: Use of the Alloc flag will increase the time required to start jobs.
+# * Contain: At job allocation time, use the ProcTrack plugin to create a job container
+#   on all allocated compute nodes. This container may be used for user processes not
+#   launched under Slurm control, for example pam_slurm_adopt may place processes
+#   launched through a direct user login into this container. If using pam_slurm_adopt,
+#   then ProcTrackType must be set to either proctrack/cgroup or proctrack/cray_aries.
+#   Setting the Contain implicitly sets the Alloc flag.
+# * X11: Enable Slurm's built-in X11 forwarding capabilities.
+#   This is incompatible with ProctrackType=proctrack/linuxproc.
+#   Setting the X11 flag implicitly enables both Contain and Alloc flags as well.
+PrologFlags=Contain,X11
 Prolog={{SlurmScriptsDir}}/prolog.sh
 PrologSlurmctld={{SlurmScriptsDir}}/slurmctld-prolog.sh
 # ReturnToService


### PR DESCRIPTION
Saw a comment on mailing list that contain is required for cgroups.

Add x11 so that srun can run X11 applications on the user's desktop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
