### PR TITLE
Document job preemption

### DIFF
--- a/docs/job_preemption.md
+++ b/docs/job_preemption.md
@@ -1,0 +1,15 @@
+# Job Preemption
+
+The cluster is set up with an interactive partition that has a higher priority than all other partitions.
+All other partitions are configured to allow jobs to be preempted by the interactive queue.
+When an interactive job is pending because of compute resources then it can preempt another job and use the resources.
+The preempted job will be requeued so that it will rerun when resources become available.
+
+Jobs should rarely pend because of lack of compute resources if you've defined enough compute nodes in your configuration.
+The more likely reason for a job to pend is if it requires a license and all available licenses are already being used.
+However, it appears that Slurm doesn't support preemption based on licenses availability so if the reason a job is pending is
+because of licenses then it will not preempt jobs in a lower priority queue even if doing so would free up a license.
+
+## Documentation
+
+https://slurm.schedmd.com/preempt.html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ nav:
   - 'index.md'
   - 'deploy.md'
   - 'run_jobs.md'
+  - 'job_preemption.md'
   - 'onprem.md'
   - 'soca_integration.md'
   - 'f1-ami.md'

--- a/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/etc/slurm.conf
+++ b/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/etc/slurm.conf
@@ -32,6 +32,7 @@ CommunicationParameters = NoAddrCache
 #
 Epilog={{SlurmScriptsDir}}/epilog.sh
 EpilogSlurmctld={{SlurmScriptsDir}}/slurmctld-epilog.sh
+# JobRequeue must be set to 1 to enable preemption to requeue jobs.
 JobRequeue=1
 JobSubmitPlugins=defaults
 LaunchParameters=enable_nss_slurm


### PR DESCRIPTION
Job preemption is working if a job in a higher priority queue is pending because of compute resources, however, not if because of licenses.

I opened an issue with SchedMD on this issue.

Resolves #84

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
