### PR TITLE
Add SlurmConfOverrides config

### DIFF
--- a/source/cdk/config_schema.py
+++ b/source/cdk/config_schema.py
@@ -220,6 +220,10 @@ config_schema = Schema(
                 Optional('PreemptMode', default='REQUEUE'): And(str, lambda s: s in ['OFF', 'CANCEL', 'GANG', 'REQUEUE', 'SUSPEND']),
                 Optional('PreemptType', default='preempt/partition_prio'): And(str, lambda s: s in ['preempt/none', 'preempt/partition_prio', 'preempt/qos']),
                 Optional('PreemptExemptTime', default='0'): str,
+                #
+                # SlurmConfOverrides:
+                #     File that will be included at end of slurm.conf to override configuration parameters.
+                Optional('SlurmConfOverrides'): str,
             },
             #
             # The accounting database is required to enable fairshare scheduling

--- a/source/resources/config/slurm_eda.yml
+++ b/source/resources/config/slurm_eda.yml
@@ -29,6 +29,9 @@ slurm:
       AlmaLinux: {8: [x86_64, arm64]}
       CentOS:
         7: [x86_64]
+    # OnPremComputeNodes:
+    #   ConfigFile: '/path/slurm_nodes_on_prem.conf'
+    #   CIDR: 'x.x.x.x/16'
 
   # Use defaults from schema
   storage: {'zfs': {}}

--- a/source/resources/config/slurm_nodes_on_prem.conf
+++ b/source/resources/config/slurm_nodes_on_prem.conf
@@ -1,0 +1,50 @@
+#
+# ON PREMISES COMPUTE NODES
+#
+# Config file with list of statically provisioned on-premises compute nodes that
+# are managed by this cluster.
+#
+# These nodes must be addressable on the network and firewalls must allow access on all ports
+# required by slurm.
+#
+# The compute nodes must have mounts that mirror the compute cluster including mounting the slurm file system
+# or a mirror of it.
+#
+# There are no constraints on the node names other than that they should be unique from all other nodes and are ideally descriptive.
+#
+# By giving these nodes a weight of 1 they should have highest priority for use by the scheduler.
+#
+# The example nodes are actually static EC2 nodes in an AWS VPC.
+#
+# You should also create a partition that uses these nodes and exclude the partitiion from power saving so that they alway remain powered up.
+#
+
+# Set the defaults for these nodes.
+NodeName=Default State=DOWN
+
+NodeName=onprem-c7-x86-t3-2xl-0 NodeAddr=onprem-c7-x86-t3-2xl-0.onprem.com  CPUs=4  RealMemory=30512   Feature=c7,CentOS_7_x86_64,x86_64,GHz:2.5 Weight=1
+NodeName=onprem-c7-x86-t3-2xl-1 NodeAddr=onprem-c7-x86-t3-2xl-1.onprem.com  CPUs=4  RealMemory=30512   Feature=c7,CentOS_7_x86_64,x86_64,GHz:2.5 Weight=1
+NodeName=onprem-c7-x86-t3-2xl-2 NodeAddr=onprem-c7-x86-t3-2xl-2.onprem.com  CPUs=4  RealMemory=30512   Feature=c7,CentOS_7_x86_64,x86_64,GHz:2.5 Weight=1
+NodeName=onprem-c7-x86-t3-2xl-3 NodeAddr=onprem-c7-x86-t3-2xl-3.onprem.com  CPUs=4  RealMemory=30512   Feature=c7,CentOS_7_x86_64,x86_64,GHz:2.5 Weight=1
+NodeName=onprem-c7-x86-t3-2xl-4 NodeAddr=onprem-c7-x86-t3-2xl-4.onprem.com  CPUs=4  RealMemory=30512   Feature=c7,CentOS_7_x86_64,x86_64,GHz:2.5 Weight=1
+NodeName=onprem-c7-x86-t3-2xl-5 NodeAddr=onprem-c7-x86-t3-2xl-5.onprem.com  CPUs=4  RealMemory=30512   Feature=c7,CentOS_7_x86_64,x86_64,GHz:2.5 Weight=1
+NodeName=onprem-c7-x86-t3-2xl-6 NodeAddr=onprem-c7-x86-t3-2xl-6.onprem.com  CPUs=4  RealMemory=30512   Feature=c7,CentOS_7_x86_64,x86_64,GHz:2.5 Weight=1
+NodeName=onprem-c7-x86-t3-2xl-7 NodeAddr=onprem-c7-x86-t3-2xl-7.onprem.com  CPUs=4  RealMemory=30512   Feature=c7,CentOS_7_x86_64,x86_64,GHz:2.5 Weight=1
+NodeName=onprem-c7-x86-t3-2xl-8 NodeAddr=onprem-c7-x86-t3-2xl-8.onprem.com  CPUs=4  RealMemory=30512   Feature=c7,CentOS_7_x86_64,x86_64,GHz:2.5 Weight=1
+NodeName=onprem-c7-x86-t3-2xl-9 NodeAddr=onprem-c7-x86-t3-2xl-9.onprem.com  CPUs=4  RealMemory=30512   Feature=c7,CentOS_7_x86_64,x86_64,GHz:2.5 Weight=1
+
+#
+#
+# OnPrem Partition
+#
+# The is the default partition and includes all nodes from the 1st OS.
+#
+PartitionName=onprem Default=YES PriorityTier=20000 Nodes=\
+onprem-c7-x86-t3-2xl-[0-9]
+
+#
+# Always on partitions
+#
+# Prevent the nodes from being powered down.
+#
+SuspendExcParts=onprem

--- a/source/resources/playbooks/roles/SlurmCtl/tasks/slurm_configuration.yml
+++ b/source/resources/playbooks/roles/SlurmCtl/tasks/slurm_configuration.yml
@@ -72,10 +72,14 @@
       set -ex
       cp {{INSTANCE_CONFIG_LOCAL_PATH}} {{INSTANCE_CONFIG_PATH}}
       cd {{SlurmScriptsDir}}
-      if ! ./slurm_ec2_create_node_conf.py --config-file {{INSTANCE_CONFIG_LOCAL_PATH}} --az-info-file {{SlurmConfigDir}}/AZInfo.json -o {{SlurmEtcDir}}/slurm_nodes.conf.new --instance-types-json {{SlurmConfigDir}}/InstanceTypes.json --instance-type-info-json {{SlurmConfigDir}}/instance-type-info.json; then
+      rm -f {{SlurmConfigDir}}/instance-type-info.new.json
+      rm -f {{SlurmEtcDir}}/slurm_nodes.conf.new
+      if ! ./slurm_ec2_create_node_conf.py --config-file {{INSTANCE_CONFIG_LOCAL_PATH}} --az-info-file {{SlurmConfigDir}}/AZInfo.json -o {{SlurmEtcDir}}/slurm_nodes.conf.new --instance-types-json {{SlurmConfigDir}}/InstanceTypes.json --instance-type-info-json {{SlurmConfigDir}}/instance-type-info.new.json; then
+          rm -f {{SlurmConfigDir}}/instance-type-info.new.json
           rm -f {{SlurmEtcDir}}/slurm_nodes.conf.new
           exit 1
       fi
+      mv {{SlurmConfigDir}}/instance-type-info.new.json {{SlurmConfigDir}}/instance-type-info.json
   tags:
     - slurm_nodes_conf
 
@@ -114,38 +118,6 @@
     backup: yes
   register: slurm_licenses_conf_result
 
-- name: Configure remote licenses
-  when: PrimaryController|bool and (AccountingStorageHost != '') and Licenses
-  shell:
-    cmd: |
-      set -ex
-      # Add or update configured licenses
-      declare -A licenses
-      {% for lic in Licenses -%}
-      license='{{lic}}'
-      # Using '@' for the port separator instead of ':' because sbatch doesn't work if ':' is in the server name.
-      server='{% if 'Server' in Licenses[lic] %}{{Licenses[lic].Server}}{% if 'Port' in Licenses[lic] %}@{{Licenses[lic].Port}}{% endif %}{% else %}slurmdb{% endif %}'
-      count='{{Licenses[lic].Count}}'
-      licenses["$license@$server"]="$count"
-      if ! {{SlurmBinDir}}/sacctmgr -i add resource type=License name=$license server=$server{% if 'ServerType' in Licenses[lic] %} servertype={{Licenses[lic].ServerType}}{% endif %} count={{Licenses[lic].Count}} cluster={{ClusterName}} percentallowed=100; then
-          {{SlurmBinDir}}/sacctmgr -i modify resource name=$license server=$server set{% if 'ServerType' in Licenses[lic] %} servertype={{Licenses[lic].ServerType}}{% endif %} count={{Licenses[lic].Count}}
-
-      fi
-      {% endfor -%}
-
-      # Remove deleted licenses
-      configured_licenses_and_servers=( $({{SlurmBinDir}}/sacctmgr --noheader --parsable2 show resource Clusters={{ClusterName}} format=name,server) )
-      echo ${configured_licenses_and_servers[@]}
-      for configured_license_and_server in ${configured_licenses_and_servers[@]}; do
-          configured_license=$(echo $configured_license_and_server | cut -d '|' -f 1)
-          configured_server=$(echo $configured_license_and_server | cut -d '|' -f 2)
-          if [ -z ${licenses["$configured_license@$configured_server"]} ]; then
-              {{SlurmBinDir}}/sacctmgr -i delete resource name=$configured_license server=$configured_server
-          fi
-      done
-
-  register: remote_slurm_licenses_conf_result
-
 - name: Create slurm_tres.conf
   when: PrimaryController|bool
   template:
@@ -156,6 +128,18 @@
     mode: 0664
     backup: yes
   register: slurm_tres_conf_result
+
+- name: Create {{SLURM_CONF_OVERRIDES_PATH}}
+  when: PrimaryController|bool and SLURM_CONF_OVERRIDES_LOCAL_PATH is defined and SLURM_CONF_OVERRIDES_PATH is defined
+  copy:
+    dest: "{{SLURM_CONF_OVERRIDES_PATH}}"
+    remote_src: yes
+    src:  "{{SLURM_CONF_OVERRIDES_LOCAL_PATH}}"
+    owner: root
+    group: root
+    mode: 0644
+    backup: yes
+  register: slurm_conf_overrides_result
 
 - name: Create {{SlurmEtcDir}}/slurm.conf
   when: PrimaryController|bool
@@ -240,7 +224,7 @@
     timeout: 1800 # 30 minutes
 
 - name: Restart slurmctld
-  when: ansible_facts.services['slurmctld.service']['state'] == 'running' and (cgroup_conf_result.changed or slurm_licenses_conf_result.changed or slurm_tres_conf_result.changed or slurm_conf_result.changed or slurm_nodes_conf_result.changed or slurm_nodes_on_prem_conf_result.changed or sysconfig_slurmctld_result.changed or slurmctld_service_result.changed)
+  when: ansible_facts.services['slurmctld.service']['state'] == 'running' and (cgroup_conf_result.changed or slurm_licenses_conf_result.changed or slurm_tres_conf_result.changed or slurm_conf_result.changed or slurm_nodes_conf_result.changed or slurm_nodes_on_prem_conf_result.changed or slurm_conf_overrides_result.changed or sysconfig_slurmctld_result.changed or slurmctld_service_result.changed)
   systemd:
     name: slurmctld
     enabled: yes
@@ -265,6 +249,40 @@
     host: "127.0.0.1"
     port: "6817"
     timeout: 1800 # 30 minutes
+
+- name: Configure remote licenses
+  # This uses sacctmcr so must do this after slurmctld and slurmd are working.
+  when: PrimaryController|bool and (AccountingStorageHost != '') and Licenses
+  shell:
+    cmd: |
+      set -ex
+      # Add or update configured licenses
+      declare -A licenses
+      {% for lic in Licenses -%}
+      license='{{lic}}'
+      # Using '@' for the port separator instead of ':' because sbatch doesn't work if ':' is in the server name.
+      server='{% if 'Server' in Licenses[lic] %}{{Licenses[lic].Server}}{% if 'Port' in Licenses[lic] %}@{{Licenses[lic].Port}}{% endif %}{% else %}slurmdb{% endif %}'
+      count='{{Licenses[lic].Count}}'
+      licenses["$license@$server"]="$count"
+      if ! {{SlurmBinDir}}/sacctmgr -i add resource type=License name=$license server=$server{% if 'ServerType' in Licenses[lic] %} servertype={{Licenses[lic].ServerType}}{% endif %} count={{Licenses[lic].Count}} cluster={{ClusterName}} percentallowed=100; then
+          # Exit 1: Nothing new added.
+          {{SlurmBinDir}}/sacctmgr -i modify resource name=$license server=$server set{% if 'ServerType' in Licenses[lic] %} servertype={{Licenses[lic].ServerType}}{% endif %} count={{Licenses[lic].Count}}
+
+      fi
+      {% endfor -%}
+
+      # Remove deleted licenses
+      configured_licenses_and_servers=( $({{SlurmBinDir}}/sacctmgr --noheader --parsable2 show resource Clusters={{ClusterName}} format=name,server) )
+      echo ${configured_licenses_and_servers[@]}
+      for configured_license_and_server in ${configured_licenses_and_servers[@]}; do
+          configured_license=$(echo $configured_license_and_server | cut -d '|' -f 1)
+          configured_server=$(echo $configured_license_and_server | cut -d '|' -f 2)
+          if [ -z ${licenses["$configured_license@$configured_server"]} ]; then
+              {{SlurmBinDir}}/sacctmgr -i delete resource name=$configured_license server=$configured_server
+          fi
+      done
+
+  register: remote_slurm_licenses_conf_result
 
 - name: Start slurm_down_nodes_clean
   when: PrimaryController|bool

--- a/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/etc/slurm.conf
+++ b/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/etc/slurm.conf
@@ -316,3 +316,6 @@ include slurm_nodes.conf
 include {{ON_PREM_COMPUTE_NODES_CONFIG}}
 {% endif %}
 include slurm_tres.conf
+{% if SLURM_CONF_OVERRIDES_PATH is defined %}
+include {{SLURM_CONF_OVERRIDES_PATH}}
+{% endif %}


### PR DESCRIPTION
Allow overrides to be added at end of slurm.conf

Change the order of slurm_nodes.conf to sort nodes by weight and to put spot nodes first.
This partially for better organization and partly to see if putting spot nodes first will let the scheduler pick them since it appears to be ignoring weight when scheduling powered down nodes.

Resolves #99

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
