### PR TITLE
Update slurm_nodes.conf daily

### DIFF
--- a/source/cdk/cdk_slurm_stack.py
+++ b/source/cdk/cdk_slurm_stack.py
@@ -2156,6 +2156,7 @@ class CdkSlurmStack(Stack):
                 iam.PolicyStatement(
                     effect = iam.Effect.ALLOW,
                     actions = [
+                        'ec2:DescribeAvailabilityZones',
                         'ec2:DescribeInstances',
                         'ec2:DescribeInstanceTypes',
                         'ec2:DescribeSpotPriceHistory',

--- a/source/resources/playbooks/roles/SlurmCtl/tasks/slurm_configuration.yml
+++ b/source/resources/playbooks/roles/SlurmCtl/tasks/slurm_configuration.yml
@@ -291,6 +291,16 @@
     daemon_reload: yes
     state: started
 
+- name: Create /etc/cron.d/slurm_accounts
+  when: PrimaryController|bool
+  template:
+    src:   etc/cron.d/slurm_accounts
+    dest: /etc/cron.d/slurm_accounts
+    owner: root
+    group: root
+    mode: 0600
+    force: yes
+
 - name: Create /etc/cron.d/slurm_cloudwatch
   when: PrimaryController|bool
   template:
@@ -301,11 +311,11 @@
     mode: 0600
     force: yes
 
-- name: Create /etc/cron.d/slurm_accounts
+- name: Create /etc/cron.d/slurm_nodes_conf
   when: PrimaryController|bool
   template:
-    src:   etc/cron.d/slurm_accounts
-    dest: /etc/cron.d/slurm_accounts
+    src:   etc/cron.d/slurm_nodes_conf
+    dest: /etc/cron.d/slurm_nodes_conf
     owner: root
     group: root
     mode: 0600

--- a/source/resources/playbooks/roles/SlurmCtl/tasks/slurm_scripts.yml
+++ b/source/resources/playbooks/roles/SlurmCtl/tasks/slurm_scripts.yml
@@ -143,6 +143,15 @@
     group: root
     mode: 0775
 
+- name: Create {{SlurmScriptsDir}}/update_slurm_nodes_conf.sh
+  when: PrimaryController|bool
+  template:
+    dest: "{{SlurmScriptsDir}}/update_slurm_nodes_conf.sh"
+    src:  opt/slurm/cluster/bin/update_slurm_nodes_conf.sh
+    owner: root
+    group: root
+    mode: 0775
+
 # Put a copy of slurm_ec2_create_node_conf.py on file system so can be run on any instance
 - name: Create {{SlurmScriptsDir}}/slurm_ec2_create_node_conf.py
   when: PrimaryController|bool

--- a/source/resources/playbooks/roles/SlurmCtl/templates/etc/cron.d/slurm_nodes_conf
+++ b/source/resources/playbooks/roles/SlurmCtl/templates/etc/cron.d/slurm_nodes_conf
@@ -1,0 +1,5 @@
+# Update slurm_nodes.conf to get latest instance types and pricing
+MAILTO=''
+SLURM_ROOT={{SlurmRoot}}
+PATH="{{SlurmScriptsDir}}:{{SlurmBinDir}}:/sbin:/bin:/usr/sbin:/usr/bin"
+0 0 * * * root {{SlurmScriptsDir}}/update_slurm_nodes_config.sh

--- a/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/bin/update_slurm_nodes_conf.sh
+++ b/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/bin/update_slurm_nodes_conf.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ex
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Update slurm_nodes.conf
+
+cd {{SlurmScriptsDir}}
+rm -f {{SlurmConfigDir}}/instance-type-info.new.json
+rm -f {{SlurmEtcDir}}/slurm_nodes.conf.new
+if ! ./slurm_ec2_create_node_conf.py --config-file {{INSTANCE_CONFIG_LOCAL_PATH}} --az-info-file {{SlurmConfigDir}}/AZInfo.json -o {{SlurmEtcDir}}/slurm_nodes.conf.new --instance-types-json {{SlurmConfigDir}}/InstanceTypes.json --instance-type-info-json {{SlurmConfigDir}}/instance-type-info.new.json; then
+    rm -f {{SlurmConfigDir}}/instance-type-info.new.json
+    rm -f {{SlurmEtcDir}}/slurm_nodes.conf.new
+    exit 1
+fi
+if ! diff -q {{SlurmConfigDir}}/instance-type-info.json {{SlurmConfigDir}}/instance-type-info.new.json; then
+    cp {{SlurmConfigDir}}/instance-type-info.json {{SlurmConfigDir}}/instance-type-info.json.$(date '+%Y-%m-%d@%H:%M:%S')
+    mv {{SlurmConfigDir}}/instance-type-info.new.json {{SlurmConfigDir}}/instance-type-info.json
+fi
+if ! diff -q {{SlurmEtcDir}}/slurm_nodes.conf {{SlurmEtcDir}}/slurm_nodes.conf.new; then
+    cp {{SlurmEtcDir}}/slurm_nodes.conf {{SlurmEtcDir}}/slurm_nodes.conf.$(date '+%Y-%m-%d@%H:%M:%S')
+    mv {{SlurmEtcDir}}/slurm_nodes.conf.new {{SlurmEtcDir}}/slurm_nodes.conf
+    systemctl restart slurmctld
+    systemctl status slurmctld
+fi


### PR DESCRIPTION
This will pick up any new instance types and refresh the pricing that's reflected in the compute node weights.

Fix how spot pricing is gotten.

Resolves #91

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
