### PR TITLE
Enable slurmrestd to be called from Lambdas

### DIFF
--- a/docs/delete-cluster.md
+++ b/docs/delete-cluster.md
@@ -1,0 +1,45 @@
+# Delete Cluster
+
+Most of the resources can be deleted by simply deleting the cluster's CloudFormation stack.
+However, there a couple of resources that must be manually deleted:
+
+* The Slurm RDS database
+* The Slurm file system
+
+The deletion of the CloudFormation stack will fail because of these 2 resources and some resources that are used
+by them will also fail to delete.
+Manually delete the resources and then retry deleting the CloudFormation stack.
+
+## Manually Delete RDS Database
+
+If the database contains production data then it is highly recommended that you back up the data.
+You could also keep the database and use it for creating new clusters.
+
+
+Even after deleting the database CloudFormation may say that it failed to delete.
+Confirm in the RDS console that it deleted and then ignore the resource when retrying the stack deletion.
+
+* Go the the RDS console
+* Select Databases on the left
+* Remove deletion protection
+    * Select the cluster's database
+    * Click `Modify`
+    * Expand `Additional scaling configuration`
+    * Uncheck `Scale the capacity to 0 ACIs when cluster is idle`
+    * Uncheck `Enable deletion protection`
+    * Click `Continue`
+    * Select `Apply immediately`
+    * Click `Modify cluster`
+* Delete the database
+    * Select the cluster's database
+    * Click `Actions` -> `Delete`
+    * Click `Delete DB cluster`
+
+## Manually delete the Slurm file system
+
+### FSx for OpenZfs
+
+* Go to the FSx console
+* Select the cluster's file system
+* Click `Actions` -> `Delete file system`
+* Click `Delete file system`

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -1,9 +1,9 @@
 # Slurm REST API
 
-The Slurm REST API give a programmatic way to access the features of Slurm.
+The [Slurm REST API](https://slurm.schedmd.com/rest_api.html) give a programmatic way to access the features of Slurm.
 The REST API can be used, for example, to use a Lambda function to submit jobs to the Slurm cluster.
 
-## Host to use the REST API
+## How to use the REST API
 
 The following shows how to run a simple REST call.
 
@@ -15,3 +15,9 @@ wget --header "X-SLURM-USER-TOKEN: $SLURM_JWT" --header "X-SLURM-USER-NAME: $USE
 ```
 
 The REST API is documented at [https://slurm.schedmd.com/rest_api.html](https://slurm.schedmd.com/rest_api.html).
+
+The token returned by `scontrol token` has a default lifetime of 3600 seconds (1 hour).
+For automation, a cron job on the Slurm controller creates a new token for the `root` and `slurmrestd` users every 30 minutes and stores them in SSM Parameter Store at `/{{ClusterName}}/slurmrestd/jwt/{{user_name}}`.
+These tokens can be used by automations such as a Lambda function to access the REST API.
+An example Lambda function called `{{ClusterName}}-CallSlurmRestApiLambda` shows how to call various API functions.
+You can use this as a template to write functions that use your Slurm cluster for automations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
   - 'federation.md'
   - 'multi-region.md'
   - 'plugin-integration.md'
+  - 'delete-cluster.md'
   - 'implementation.md'
   - 'debug.md'
 strict: true

--- a/source/resources/lambdas/CallSlurmRestApi/CallSlurmRestApi.py
+++ b/source/resources/lambdas/CallSlurmRestApi/CallSlurmRestApi.py
@@ -1,0 +1,204 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+'''
+Example showing how to call Slurm REST API from a Lambda function.
+'''
+
+import boto3
+import json
+import logging
+from os import environ
+from urllib.parse import urlencode
+import urllib3
+
+logging.getLogger().setLevel(logging.INFO)
+
+class SlurmRestApi:
+    def __init__(self, cluster_name:str, slurm_rest_api_version:str, slurmrestd_url:str, user_name:str) -> None:
+        self.cluster_name = cluster_name
+        self.slurm_rest_api_version = slurm_rest_api_version
+        self.slurmrestd_url = slurmrestd_url
+        self.user_name = user_name
+
+        ssm_client = boto3.client('ssm')
+        parameter_name = f"/{cluster_name}/slurmrestd/jwt/{user_name}"
+        logging.debug(f"Getting jwt token from {parameter_name}")
+        self.jwt_token = ssm_client.get_parameter(Name=parameter_name)['Parameter']['Value']
+        logging.debug(f"jwt token: {self.jwt_token}")
+
+        self.http = urllib3.PoolManager()
+
+    VALID_REQUEST_TYPES = [
+        'DELETE',
+        'GET',
+        'POST',
+    ]
+
+    def _request(self, request_type:str, api_path:str, fields={}):
+        assert request_type in self.VALID_REQUEST_TYPES
+        url = f"{self.slurmrestd_url}/{api_path}"
+        headers = {
+            'X-SLURM-USER-TOKEN': self.jwt_token,
+            'X-SLURM-USER-NAME': self.user_name,
+            }
+        if request_type == 'POST':
+            headers['Content-Type'] = 'application/json'
+            body = json.dumps(fields).encode('utf-8')
+        else:
+            body = None
+        response = self.http.request(
+            request_type,
+            url,
+            headers={
+                'X-SLURM-USER-TOKEN': self.jwt_token,
+                'X-SLURM-USER-NAME': self.user_name,
+                'Content-Type': 'application/json'
+            },
+            body = body
+            )
+        logging.debug(f"status: {response.status}")
+        logging.debug(f"response: {response}")
+        logging.debug(f"response: {response.data}")
+        logging.debug(f"response: {response.data.decode('utf-8')}")
+        if response.status == 200:
+            json_response = json.loads(response.data.decode('utf-8'))
+            return json_response
+        try:
+            json_response = json.loads(response.data.decode('utf-8'))
+            logging.error(f"response:\n{json.dumps(json_response, indent=4)}")
+        except:
+            logging.error(f"response: {json.dumps(response.data.decode('utf-8'), indent=4)}")
+        raise RuntimeError(f"{request_type} {url} failed with status={response.status}")
+
+    def delete_node(self, node_name:str):
+        return self._request('DELETE', f"slurm/v{self.slurm_rest_api_version}/node/{node_name}")
+
+    def diag(self):
+        return self._request('GET', f"slurm/v{self.slurm_rest_api_version}/diag")
+
+    def scancel(self, job_id):
+        return self._request('DELETE', f"slurm/v{self.slurm_rest_api_version}/job/{job_id}")
+
+    def get_job_info(self, job_id:str):
+        return self._request('GET', f"slurm/v{self.slurm_rest_api_version}/job/{job_id}")
+
+    def get_all_job_info(self):
+        return self._request('GET', f"slurm/v{self.slurm_rest_api_version}/jobs")
+
+    def get_licenses(self):
+        return self._request('GET', f"slurm/v{self.slurm_rest_api_version}/licenses")
+
+    def get_node_info(self, node_name:str):
+        return self._request('GET', f"slurm/v{self.slurm_rest_api_version}/node/{node_name}")
+
+    def get_all_node_info(self):
+        return self._request('GET', f"slurm/v{self.slurm_rest_api_version}/nodes")
+
+    def get_partition_info(self, partition_name:str):
+        return self._request('GET', f"slurm/v{self.slurm_rest_api_version}/partition/{partition_name}")
+
+    def get_all_partition_info(self):
+        return self._request('GET', f"slurm/v{self.slurm_rest_api_version}/partitions")
+
+    def ping(self):
+        return self._request('GET', f"slurm/v{self.slurm_rest_api_version}/ping")
+
+    def submit(self, name:str, ntasks:int, nodes: int, script:str, constraints:str):
+        fields = {
+            "job": {
+                "name": name,
+                "ntasks": ntasks,
+                "nodes": nodes,
+                "constraints": constraints,
+                "current_working_directory": f"/data/home/{self.user_name}",
+                "standard_input": "/dev/null",
+                "standard_output": f"/data/home/{self.user_name}/stdio.txt",
+                "standard_error": f"/data/home/{self.user_name}/stderr.txt",
+                "environment": {
+                    "PATH": "/bin:/usr/bin/:/usr/local/bin/",
+                    "LD_LIBRARY_PATH": "/lib/:/lib64/:/usr/local/lib"
+                    }
+                },
+            "script": script
+            }
+        url = f"slurm/v{self.slurm_rest_api_version}/job/submit"
+        return self._request('POST', url, fields)
+
+def lambda_handler(event, context):
+    try:
+        logging.debug(f"event:\n{json.dumps(event, indent=4)}")
+
+        s3_bucket = event['Records'][0]['s3']['bucket']['name']
+        s3_key    = event['Records'][0]['s3']['object']['key']
+
+        logging.info(f"Triggered by s3 put to s3://{s3_bucket}/{s3_key}")
+
+        cluster_name = environ['CLUSTER_NAME']
+        slurm_rest_api_version = environ['SLURM_REST_API_VERSION']
+        slurmrestd_url = environ['SLURMRESTD_URL']
+        user_name = 'root'
+        logging.info(f"CLUSTER_NAME: {cluster_name}")
+        logging.info(f"SLURM_REST_API_VERSION: {slurm_rest_api_version}")
+        logging.info(f"SLURMRESTD_URL: {slurmrestd_url}")
+        logging.info(f"user name: {user_name}")
+
+        slurm_rest_api = SlurmRestApi(cluster_name, slurm_rest_api_version, slurmrestd_url, user_name)
+
+        json_response = slurm_rest_api.diag()
+        logging.info(f"diag:\n{json.dumps(json_response, indent=4)}")
+
+        json_response = slurm_rest_api.ping()
+        logging.info(f"ping response:\n{json.dumps(json_response, indent=4)}")
+
+        # Get list of nodes
+        json_response = slurm_rest_api.get_all_node_info()
+        logging.info(f"{len(json_response['nodes'])} nodes")
+        node_state_dict = {}
+        for node_dict in json_response['nodes']:
+            node_state_dict[node_dict['state']] = node_state_dict.get(node_dict['state'], 0) + 1
+        for node_state in sorted(node_state_dict.keys()):
+            logging.info(f"    {node_state}: {node_state_dict[node_state]}")
+        # logging.info(f"all node info:\n{json.dumps(json_response, indent=4)}")
+
+        # Get list of partitions
+        json_response = slurm_rest_api.get_all_partition_info()
+        #logging.info(f"all partition info: {json_response}")
+        logging.info(f"{len(json_response['partitions'])} partitions:")
+        for partition_dict in sorted(json_response['partitions'], key=lambda p: p['name']):
+            logging.info(f"    {partition_dict['name']}")
+
+        # Get list of licenses
+        json_response = slurm_rest_api.get_licenses()
+        logging.info(f"{len(json_response['licenses'])} licenses:")
+        for license_dict in sorted(json_response['licenses'], key=lambda l: l['LicenseName']):
+            logging.info(f"    license_dict['LicenseName']: total={license_dict['Total']:5} used={license_dict['Used']:5} free={license_dict['Free']:5}")
+
+        json_response = slurm_rest_api.get_all_job_info()
+        logging.info(f"{len(json_response['jobs'])} jobs:")
+        for job_dict in sorted(json_response['jobs'], key=lambda j: j['job_id']):
+            logging.info(f"    job_dict['job_id']: user_name={job_dict['user_name']} partition={job_dict['partition']} job_state={job_dict['job_state']}")
+
+        # Test submitting a job
+        json_response = slurm_rest_api.submit(name='rest-test', ntasks=1, nodes=1, constraints='c7&c6i.large&spot', script=f"#!/bin/bash\necho 'I am from the REST API'")
+        logging.info(f"Submitted {json_response['job_id']}")
+        json_response = slurm_rest_api.get_job_info(json_response['job_id'])
+
+    except Exception as e:
+        logging.exception(str(e))
+        raise

--- a/source/resources/lambdas/DeconfigureCluster/DeconfigureCluster.py
+++ b/source/resources/lambdas/DeconfigureCluster/DeconfigureCluster.py
@@ -23,16 +23,19 @@ Unmount the slurm file system.
 '''
 import cfnresponse
 import boto3
+import json
 import logging
 from textwrap import dedent
 
 logging.getLogger().setLevel(logging.INFO)
+#logging.getLogger().setLevel(logging.DEBUG)
 
 def lambda_handler(event, context):
     try:
-        logging.info("event: {}".format(event))
+        logging.debug("event: {}".format(event))
         requestType = event['RequestType']
         if requestType != 'Delete':
+            logging.info(f"requestType={requestType} != Delete so nothing to do.")
             cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, "")
             return
 
@@ -56,8 +59,10 @@ def lambda_handler(event, context):
         logging.info(f'cmd: {cmd}')
 
         targets = []
+        logging.info(f"submitter_instance_tags:\n{submitter_instance_tags}")
         for tag, values in submitter_instance_tags.items():
             targets.append({'Key': f'tag:{tag}', 'Values': values})
+        logging.info(f"Targets:\n{json.dumps(targets, indent=4)}")
         response = ssm_client.send_command(
             Targets = targets,
             DocumentName = 'AWS-RunShellScript',

--- a/source/resources/playbooks/roles/SlurmCtl/tasks/main.yml
+++ b/source/resources/playbooks/roles/SlurmCtl/tasks/main.yml
@@ -46,6 +46,7 @@
 - { include: user_slurm.yml, tags: users }
 - { include: slurm_directories.yml, tags: slurm_directories }
 - { include: slurm_scripts.yml, tags: slurm_scripts }
+- { include: slurmrestd.yml, tags: slurmrestd }
 - { include: slurm_accounting.yml, tags: slurm_accounting }
 - { include: munge.yml, tags: munge }
 - { include: slurm_modulefiles.yml, tags: slurm_modulefiles }

--- a/source/resources/playbooks/roles/SlurmCtl/tasks/slurm_configuration.yml
+++ b/source/resources/playbooks/roles/SlurmCtl/tasks/slurm_configuration.yml
@@ -311,7 +311,10 @@
       licenses["$license@$server"]="$count"
       if ! {{SlurmBinDir}}/sacctmgr -i add resource type=License name=$license server=$server{% if 'ServerType' in Licenses[lic] %} servertype={{Licenses[lic].ServerType}}{% endif %} count={{Licenses[lic].Count}} cluster={{ClusterName}} percentallowed=100; then
           # Exit 1: Nothing new added.
-          {{SlurmBinDir}}/sacctmgr -i modify resource name=$license server=$server set{% if 'ServerType' in Licenses[lic] %} servertype={{Licenses[lic].ServerType}}{% endif %} count={{Licenses[lic].Count}}
+          {{SlurmBinDir}}/sacctmgr -i modify resource name=$license server=$server set count={{Licenses[lic].Count}}
+
+          # This is required or else license count will stay at 0
+          {{SlurmBinDir}}/sacctmgr -i modify resource name=$license server=$server cluster={{ClusterName}} set percentallowed=100
 
       fi
       {% endfor -%}

--- a/source/resources/playbooks/roles/SlurmCtl/tasks/slurmrestd.yml
+++ b/source/resources/playbooks/roles/SlurmCtl/tasks/slurmrestd.yml
@@ -1,0 +1,30 @@
+---
+
+- name: Create {{SlurmScriptsDir}}/update_slurmrestd_jwt_parameter.sh
+  when: PrimaryController|bool
+  template:
+    dest: "{{SlurmScriptsDir}}/update_slurmrestd_jwt_parameter.sh"
+    src:   opt/slurm/cluster/bin/update_slurmrestd_jwt_parameter.sh
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Cron to update slurmrestd JWT for root
+  when: PrimaryController|bool
+  template:
+    src:   etc/cron.d/update_slurmrestd_jwt_for_root
+    dest: /etc/cron.d/update_slurmrestd_jwt_for_root
+    owner: root
+    group: root
+    mode: 0600
+    force: yes
+
+- name: Cron to update slurmrestd JWT for slurmrestd
+  when: PrimaryController|bool
+  template:
+    src:   etc/cron.d/update_slurmrestd_jwt_for_slurmrestd
+    dest: /etc/cron.d/update_slurmrestd_jwt_for_slurmrestd
+    owner: root
+    group: root
+    mode: 0600
+    force: yes

--- a/source/resources/playbooks/roles/SlurmCtl/templates/etc/cron.d/update_slurmrestd_jwt_for_root
+++ b/source/resources/playbooks/roles/SlurmCtl/templates/etc/cron.d/update_slurmrestd_jwt_for_root
@@ -1,0 +1,4 @@
+MAILTO=''
+SLURM_ROOT={{SlurmRoot}}
+PATH="{{SlurmScriptsDir}}:{{SlurmBinDir}}:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"
+*/30 * * * * root {{SlurmScriptsDir}}/update_slurmrestd_jwt_parameter.sh root {{SlurmrestdJwtForRootParameter}}

--- a/source/resources/playbooks/roles/SlurmCtl/templates/etc/cron.d/update_slurmrestd_jwt_for_slurmrestd
+++ b/source/resources/playbooks/roles/SlurmCtl/templates/etc/cron.d/update_slurmrestd_jwt_for_slurmrestd
@@ -1,0 +1,4 @@
+MAILTO=''
+SLURM_ROOT={{SlurmRoot}}
+PATH="{{SlurmScriptsDir}}:{{SlurmBinDir}}:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"
+*/30 * * * * root {{SlurmScriptsDir}}/update_slurmrestd_jwt_parameter.sh slurmrestd {{SlurmrestdJwtForSlurmrestdParameter}}

--- a/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/bin/update_slurmrestd_jwt_parameter.sh
+++ b/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/bin/update_slurmrestd_jwt_parameter.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -xe
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+exec 1> >(logger -s -t update_slurmrestd_jwt_parameter) 2>&1
+
+userid=$1
+parameter_name=$2
+
+. <({{SlurmBinDir}}/scontrol token)
+aws ssm put-parameter --region {{Region}} --name $parameter_name --type String --value "$SLURM_JWT" --overwrite

--- a/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/modules/modulefiles/slurm/.template
+++ b/source/resources/playbooks/roles/SlurmCtl/templates/opt/slurm/cluster/modules/modulefiles/slurm/.template
@@ -130,7 +130,7 @@ if { [ module-info mode load ] || [ module-info mode display ] } {
         setenv SQUEUE_SORT_SET ""
     }
     if { ! ( [ info exists ::env(SQUEUE_FORMAT) ] || [ info exists ::env(SQUEUE_FORMAT2) ] ) } {
-        setenv SQUEUE_FORMAT2 "Cluster:16 ,Partition:15 ,JobArrayId:16 ,Priority:12 ,State:11 ,UserName:8 ,Name:16 ,NumNodes:.5 ,NumCPUs:.4 ,MinMemory:.10 ,Feature:15 ,Dependency:10 ,Licenses:8 ,ReasonList:30"
+        setenv SQUEUE_FORMAT2 "Cluster:16 ,Partition:15 ,JobArrayId:16 ,Priority:12 ,State:11 ,UserName:8 ,Name:16 ,NumNodes:.5 ,NumCPUs:.4 ,MinMemory:.10 ,Feature:15 ,Dependency:10 ,Licenses:8 ,ReasonList:35"
         #
         # Time and priority information
         #setenv SQUEUE_FORMAT2 "JobId:.6 ,Partition:9 ,State:7 ,UserName:8 ,Name:16 ,SubmitTime:16 ,PendingTime:12 ,TimeLimit:18 ,EndTime:18 ,ReasonList"

--- a/source/resources/playbooks/roles/SlurmSubmitter/tasks/packages.yml
+++ b/source/resources/playbooks/roles/SlurmSubmitter/tasks/packages.yml
@@ -24,3 +24,36 @@
       - environment-modules
       - munge
       - python3
+
+- name: Install libjwt on non-Amazon arm64
+  when: not(distribution == 'Amazon' and Architecture == 'arm64')
+  yum:
+    state: present
+    name:
+      - libjwt
+
+- name: Install packages to build libjwt
+  when: distribution == 'Amazon' and Architecture == 'arm64'
+  yum:
+    state: present
+    name:
+      - autoconf
+      - automake
+      - git
+      - jansson-devel
+      - libtool
+      - openssl-devel
+
+- name: Install libjwt on Amazon arm64
+  when: distribution == 'Amazon' and Architecture == 'arm64'
+  shell: |
+    set -xe
+
+    cd /tmp
+    rm -rf libjwt
+    git clone --depth 1 --single-branch -b v1.12.0 https://github.com/benmcollins/libjwt.git libjwt
+    cd libjwt
+    autoreconf --force --install
+    ./configure --prefix=/usr/local
+    make -j
+    make install

--- a/source/resources/playbooks/roles/unmount_slurm_fs/tasks/main.yml
+++ b/source/resources/playbooks/roles/unmount_slurm_fs/tasks/main.yml
@@ -13,12 +13,14 @@
 
 - name: Unmount SLURM file system
   mount:
-    backup: yes
     fstype: "{{FileSystemType}}"
-    opts: "{{FileSystemOptions}}"
     path: "{{FileSystemMountPath}}"
-    src: "{{FileSystemMountSrc}}"
     state: absent
+
+# For some reason the ansible module is leaving the file system mounted
+- name: Unmount SLURM file system
+  shell: |
+    umount -f {{FileSystemMountPath}}
 
 - name: Remove {{FileSystemMountPath}}
   file:


### PR DESCRIPTION
Update slurmrestd JWT parameters for root and slurmrestd users.

Update Lambda runtimes to PYTHON_3_8.
Update Lambdas to run on ARM64 architecture.

Add documentation for deleting clusters.
Update permissions for DeconfigureCluster lambda so it can run commands on tagged instances.

Resolves #86
Resolves #110
Resolves #111

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
