### PR TITLE
Fix use of hpc6a instances

### DIFF
--- a/source/cdk/cdk_slurm_stack.py
+++ b/source/cdk/cdk_slurm_stack.py
@@ -520,8 +520,7 @@ class CdkSlurmStack(Stack):
         eC2InstanceTypeInfo = EC2InstanceTypeInfo(self.compute_regions.keys(), json_filename='/tmp/instance_type_info.json', debug=False)
 
         plugin = SlurmPlugin(slurm_config_file=None, region=self.region)
-        plugin.instance_type_info = eC2InstanceTypeInfo.instance_type_info
-        plugin.create_instance_family_info()
+        plugin.instance_type_and_family_info = eC2InstanceTypeInfo.instance_type_and_family_info
         self.az_info = plugin.get_az_info_from_instance_config(self.config['slurm']['InstanceConfig'])
         logger.info(f"{len(self.az_info.keys())} AZs configured: {sorted(self.az_info.keys())}")
 
@@ -2217,6 +2216,8 @@ class CdkSlurmStack(Stack):
                         'ec2:DescribeInstanceTypes',
                         'ec2:DescribeSpotPriceHistory',
                         'ec2:DescribeSubnets',
+                        'savingsplans:DescribeSavingsPlansOfferings',
+                        'savingsplans:DescribeSavingsPlansOfferingRates',
                     ],
                     # Does not support resource-level permissions and require you to choose All resources
                     resources = ["*"]

--- a/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/EC2InstanceTypeInfoPkg/get_ec2_instance_info.py
+++ b/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/EC2InstanceTypeInfoPkg/get_ec2_instance_info.py
@@ -3,13 +3,14 @@
 import argparse
 from botocore.exceptions import NoCredentialsError
 from EC2InstanceTypeInfoPkg.EC2InstanceTypeInfo import EC2InstanceTypeInfo
-import sys
+import logging
+from sys import exit
 
 if __name__ == '__main__':
     try:
         parser = argparse.ArgumentParser(description="Get EC2 instance pricing info.", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         parser.add_argument("--region", "-r", type=str, default=[], action='append', help="AWS region(s) to get info for.")
-        parser.add_argument("--input", '-i', type=str, default=None, help="JSON input file. Reads existing info from previous runs. Can speed up rerun if a region failed.")
+        parser.add_argument("--input", '-i', type=str, default=None, help="JSON input file. Reads existing info from previous runs. Can speed up rerun if it failed to collect the data for a region.")
         parser.add_argument("--output-csv", '-o', type=str, default=None, help="CSV output file. Default: instance_type_info.csv")
         parser.add_argument("--debug", "-d", action='store_const', const=True, default=False, help="Enable debug messages")
         args = parser.parse_args()
@@ -18,7 +19,8 @@ if __name__ == '__main__':
             print(f"Reading existing instance info from {args.input}")
         ec2InstanceTypeInfo = EC2InstanceTypeInfo(args.region, json_filename=args.input, debug=args.debug)
         if args.output_csv:
+            print(f"\nWriting output to CSV: {args.output_csv}")
             ec2InstanceTypeInfo.print_csv(args.output_csv)
     except NoCredentialsError as e:
         print('No AWS credentials found')
-        sys.exit(1)
+        exit(1)

--- a/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/EC2InstanceTypeInfoPkg/get_savings_plans.py
+++ b/source/resources/playbooks/roles/SlurmCtl/files/opt/slurm/cluster/bin/EC2InstanceTypeInfoPkg/get_savings_plans.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+import argparse
+import boto3
+from botocore.exceptions import NoCredentialsError
+import json
+import logging
+from sys import exit
+
+logger = logging.getLogger(__file__)
+logger_formatter = logging.Formatter('%(levelname)s:%(asctime)s: %(message)s')
+logger_streamHandler = logging.StreamHandler()
+logger_streamHandler.setFormatter(logger_formatter)
+logger.addHandler(logger_streamHandler)
+logger.setLevel(logging.INFO)
+logger.propagate = False
+
+class SavingsPlanInfo:
+
+    VALID_SAVINGS_PLAN_TYPES = [
+        'EC2Instance',
+        'Compute'
+    ]
+    VALID_DURATIONS = [1, 3]
+    VALID_PAYMENT_OPTIONS = [
+        'All Upfront',
+        'Partial Upfront',
+        'No Upfront'
+    ]
+
+    def __init__(self, region: str):
+        self._region = region
+        self._savingsplans_client = boto3.client('savingsplans', region_name=region)
+
+    def get_ec2_savings_plan_rate(self, instance_type: str, duration_years: int, payment_option: str):
+        '''
+        Get the hourly rate for the specified instance type and EC2 Saving Plan terms
+
+        Args:
+            instance_type (str): EC2 instance type
+            duration_years (int): Duration in years. 1 or 3
+            payment_option (str): 'All Upfront'|'Partial Upfront'|'No Upfront'
+        Returns:
+            float: The effective hourly rate for the savings plan
+        '''
+        assert duration_years in SavingsPlanInfo.VALID_DURATIONS
+        assert payment_option in SavingsPlanInfo.VALID_PAYMENT_OPTIONS
+
+        instance_family = instance_type.split('.')[0]
+        response = self._savingsplans_client.describe_savings_plans_offerings(
+            productType = 'EC2',
+            planTypes=['EC2Instance'],
+            currencies=['USD'],
+            filters=[
+                {'name': 'region', 'values': [self._region]},
+                {'name': 'instanceFamily', 'values': [instance_family]},
+            ],
+            durations=[duration_years * 365 * 24 * 60 * 60],
+            paymentOptions=[payment_option],
+        )['searchResults']
+        logger.debug(f"offerIDs:\n{json.dumps(response, indent=4)}")
+        if not response:
+            return None
+        offeringId = response[0]['offeringId']
+
+        response = self._savingsplans_client.describe_savings_plans_offering_rates(
+            savingsPlanOfferingIds=[offeringId],
+            products=['EC2'],
+            serviceCodes=['AmazonEC2'], # 'Compute'
+            savingsPlanTypes=['EC2Instance'],
+            savingsPlanPaymentOptions=[payment_option],
+            filters=[
+                {'name': 'region', 'values': [self._region]},
+                {'name': 'instanceType', 'values': [instance_type]},
+                {'name': 'productDescription', 'values': ['Linux/UNIX']},
+                {'name': 'tenancy', 'values': ['shared']},
+            ],
+            # usageTypes=[
+            #     'string',
+            # ],
+        )['searchResults']
+        logger.debug(json.dumps(response, indent=4))
+        if not response:
+            return None
+        return float(response[0]['rate'])
+
+    def get_compute_savings_plan_rate(self, instance_type: str, duration_years: int, payment_option: str):
+        '''
+        Get the hourly rate for the specified instance type and EC2 Saving Plan terms
+
+        Args:
+            instance_type (str): EC2 instance type
+            duration_years (int): Duration in years. 1 or 3
+            payment_option (str): 'All Upfront'|'Partial Upfront'|'No Upfront'
+        Returns:
+            float: The effective hourly rate for the savings plan
+        '''
+        assert duration_years in SavingsPlanInfo.VALID_DURATIONS
+        assert payment_option in SavingsPlanInfo.VALID_PAYMENT_OPTIONS
+
+        response = self._savingsplans_client.describe_savings_plans_offerings(
+            planTypes=['Compute'],
+            currencies=['USD'],
+            durations=[duration_years * 365 * 24 * 60 * 60],
+            paymentOptions=[payment_option],
+        )['searchResults']
+        if not response:
+            return None
+        logger.debug(f"offerings:\n{json.dumps(response, indent=4)}")
+        offeringId = response[0]['offeringId']
+
+        response = self._savingsplans_client.describe_savings_plans_offering_rates(
+            savingsPlanOfferingIds=[offeringId],
+            serviceCodes=['AmazonEC2'],
+            savingsPlanPaymentOptions=[payment_option],
+            filters=[
+                {'name': 'region', 'values': [self._region]},
+                {'name': 'instanceType', 'values': [instance_type]},
+                {'name': 'productDescription', 'values': ['Linux/UNIX']},
+                {'name': 'tenancy', 'values': ['shared']},
+            ],
+        )['searchResults']
+        logger.debug(f"rates:\n{json.dumps(response, indent=4)}")
+        if not response:
+            return None
+        return float(response[0]['rate'])
+
+def main():
+    try:
+        parser = argparse.ArgumentParser(description="Get Savings Plans rate for an EC2 instance type", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        parser.add_argument("--region", "-r", type=str, required=True, help="AWS region get info for.")
+        parser.add_argument("--instance-type", type=str, required=True, help="EC2 instance type")
+        parser.add_argument("--savings-plan-type", type=str, required=True, choices=SavingsPlanInfo.VALID_SAVINGS_PLAN_TYPES, help="Savings plan type.")
+        parser.add_argument("--duration", type=int, required=True, choices=SavingsPlanInfo.VALID_DURATIONS, help="Savings plan duration in years.")
+        parser.add_argument("--payment-option", type=str, required=True, choices=SavingsPlanInfo.VALID_PAYMENT_OPTIONS, help="Savings plan payment option.")
+        parser.add_argument("--debug", "-d", action='store_const', const=True, default=False, help="Enable debug messages")
+        args = parser.parse_args()
+
+        if args.debug:
+            logger.setLevel(logging.DEBUG)
+
+        savingsPlanInfo = SavingsPlanInfo(args.region)
+        if args.savings_plan_type == 'EC2Instance':
+            rate = savingsPlanInfo.get_ec2_savings_plan_rate(args.instance_type, duration_years=args.duration, payment_option='All Upfront')
+        elif args.savings_plan_type == 'Compute':
+            rate = savingsPlanInfo.get_compute_savings_plan_rate(args.instance_type, duration_years=args.duration, payment_option='All Upfront')
+        else:
+            raise ValueError(f'Invalid --savings-plan-type {args.savings_plan_type}')
+        print(f"{rate}")
+    except NoCredentialsError as e:
+        print('No AWS credentials found')
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/source/resources/playbooks/roles/SlurmCtl/tasks/slurm_scripts.yml
+++ b/source/resources/playbooks/roles/SlurmCtl/tasks/slurm_scripts.yml
@@ -35,6 +35,15 @@
     group: root
     mode: 0755
 
+- name: Create {{SlurmScriptsDir}}/EC2InstanceTypeInfoPkg/get_savings_plans.py
+  when: PrimaryController|bool
+  copy:
+    dest: "{{SlurmScriptsDir}}/EC2InstanceTypeInfoPkg/get_savings_plans.py"
+    src: opt/slurm/cluster/bin/EC2InstanceTypeInfoPkg/get_savings_plans.py
+    owner: root
+    group: root
+    mode: 0755
+
 - name: Create {{SlurmScriptsDir}}/EC2InstanceTypeInfoPkg/retry_boto3_throttling.py
   when: PrimaryController|bool
   copy:

--- a/source/resources/user_data/slurm_node_ami_config.sh
+++ b/source/resources/user_data/slurm_node_ami_config.sh
@@ -40,8 +40,8 @@ if [ -e /var/lib/cloud/instance/sem/ami.txt ]; then
     echo "First reboot after ami ($ami) created."
     chmod +x /root/WaitForAmi.py
     if ! /root/WaitForAmi.py --ami-id $ami --base-ssm-parameter $SlurmNodeAmiSsmParameterBaseName --instance-id $instance_id --compute-regions $ComputeRegions; then
-        echo "Could not wait for AMI. Assume it is bad and create a new one."
-        rm -f /var/lib/cloud/instance/sem/ami.txt
+        echo "Could not wait for AMI. Do not try to create a new one because it may be a problem with the WaitForAmi.py script."
+        exit 1
     else
         # Delete the semaphore so that if the instance reboots because of template changes then a new AMI will be created
         mv /var/lib/cloud/instance/sem/ami.txt /var/lib/cloud/instance/sem/$ami.txt


### PR DESCRIPTION
The plugin was seeing that the instance type is x86 and can have 2 threads and was setting CpuOptions to set the number of threads per core to 1. But this instance family has only 1 instance size and it disables hyperthreading and doesn't allow using CpuOptions.
It also doesn't have spot pricing as an option so need to check if spot pricing exists when creating spot compute nodes.

Update instance_type_info.json to save DefaultThreadsPerCore instead of CoreCount.
Sync EC2InstanceTypeInfo with the copy in hpc-cost-simulator. Replaces ThreadsPerCore.
Save ValidThreadsPerCore.
As part of the sync, rename instance_type_info to instance_type_and_family_info because in hpc-cost-simulator it contains both.
This removes the need to create instance_family_info. Adds savings plan info in pricing which slows things down and requires additional IAM permissions for the controller.

Resolves #122

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
