### PR TITLE
Remove failing condition from slurmd.service

### DIFF
--- a/source/resources/playbooks/roles/SlurmNodeAmi/templates/etc/systemd/system/slurmd.service
+++ b/source/resources/playbooks/roles/SlurmNodeAmi/templates/etc/systemd/system/slurmd.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=Slurm node daemon
+Requires=munged.service remote-fs.target
 After=munged.service network.target remote-fs.target
-ConditionPathExists={{SlurmEtcDir}}/slurm.conf
+# On CentOS 7 slurmd sometimes fails to start after reboot because of this condition.
+#ConditionPathExists={{SlurmEtcDir}}/slurm.conf
 
 [Service]
 Type=forking
@@ -14,6 +16,9 @@ LimitNOFILE=131072
 LimitMEMLOCK=infinity
 LimitSTACK=infinity
 Delegate=yes
+
+Restart=on-failure
+RestartSec=1
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Comment out the ConditionPathExists from slurd.service. It appears that the condition is being checked before the file system is mounted.

Add Requires for munged.service and remote-fs.service

Could possibly add a requires on opt-slurm-{{ClusterName}}.mount.

Resolves #133

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
