### PR TITLE
Fix create_user_groups.py when /usr/sbin not in path

### DIFF
--- a/source/resources/parallel-cluster/config/bin/on_compute_node_configured.sh
+++ b/source/resources/parallel-cluster/config/bin/on_compute_node_configured.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -x
 
+set -x
+
+exec 1> >(logger -s -t on_compute_node_configured.sh) 2>&1
+
 full_script=$(realpath $0)
 script_dir=$(dirname $full_script)
 base_script=$(basename $full_script)
@@ -20,7 +24,12 @@ if [ $full_script != $dest_script ]; then
     chmod 0700 $dest_script
 fi
 
-ansible_compute_node_vars_yml_s3_url="s3://$assets_bucket/$assets_base_key/config/ansible/ansible_compute_node_vars.yml"
+export PATH=/usr/sbin:$PATH
+
+echo "Creating users and groups"
+$config_bin_dir/create_users_groups.py -i $config_dir/users_groups.json
+
+# ansible_compute_node_vars_yml_s3_url="s3://$assets_bucket/$assets_base_key/config/ansible/ansible_compute_node_vars.yml"
 
 # # Configure using ansible
 # if ! yum list installed ansible &> /dev/null; then

--- a/source/resources/parallel-cluster/config/bin/on_compute_node_start.sh
+++ b/source/resources/parallel-cluster/config/bin/on_compute_node_start.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -x
 
+set -x
+
+exec 1> >(logger -s -t on_compute_node_start.sh) 2>&1
+
 full_script=$(realpath $0)
 script_dir=$(dirname $full_script)
 base_script=$(basename $full_script)
@@ -7,20 +11,9 @@ base_script=$(basename $full_script)
 date
 echo "Started on_compute_node_start.sh: $full_script"
 
-config_dir=/opt/slurm/config
-config_bin_dir=$config_dir/bin
+# /opt/slurm isn't mounted yet.
 
-assets_bucket={{assets_bucket}}
-assets_base_key={{assets_base_key}}
-
-dest_script="$config_bin_dir/on_compute_node_start.sh"
-if [ $full_script != $dest_script ]; then
-    echo "cp $full_script $dest_script"
-    cp $full_script $dest_script
-    chmod 0700 $dest_script
-fi
-
-$config_bin_dir/create_users_groups.py -i $config_dir/users_groups.json
+export PATH=/usr/sbin:$PATH
 
 date
 echo "Finished on_compute_node_start.sh: $full_script"

--- a/source/resources/parallel-cluster/config/bin/on_head_node_configured.sh
+++ b/source/resources/parallel-cluster/config/bin/on_head_node_configured.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -x
 
+set -x
+
+exec 1> >(logger -s -t on_head_node_configured.sh) 2>&1
+
 full_script=$(realpath $0)
 script_dir=$(dirname $full_script)
 base_script=$(basename $full_script)
@@ -18,6 +22,8 @@ if [ $full_script != $dest_script ]; then
     cp $full_script $dest_script
     chmod 0700 $dest_script
 fi
+
+export PATH=/usr/sbin:$PATH
 
 $config_bin_dir/on_head_node_start.sh
 

--- a/source/resources/parallel-cluster/config/bin/on_head_node_start.sh
+++ b/source/resources/parallel-cluster/config/bin/on_head_node_start.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -x
 
+set -x
+
+exec 1> >(logger -s -t on_head_node_start.sh) 2>&1
+
 full_script=$(realpath $0)
 script_dir=$(dirname $full_script)
 base_script=$(basename $full_script)
@@ -58,6 +62,8 @@ if ! [ -e $config_dir/users_groups.json ]; then
     $config_bin_dir/create_users_groups.py -i $config_dir/users_groups.json
 fi
 chmod 0600 $config_dir/users_groups.json
+
+export PATH=/usr/sbin:$PATH
 
 $config_bin_dir/create_users_groups.py -i $config_dir/users_groups.json
 

--- a/source/resources/parallel-cluster/config/bin/on_head_node_updated.sh
+++ b/source/resources/parallel-cluster/config/bin/on_head_node_updated.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -x
 
+set -x
+
+exec 1> >(logger -s -t on_head_node_updated.sh) 2>&1
+
 full_script=$(realpath $0)
 script_dir=$(dirname $full_script)
 base_script=$(basename $full_script)
@@ -16,6 +20,8 @@ if [ $full_script != $dest_script ]; then
     cp $full_script $dest_script
     chmod 0700 $dest_script
 fi
+
+export PATH=/usr/sbin:$PATH
 
 $config_bin_dir/on_head_node_configured.sh
 


### PR DESCRIPTION
If /usr/sbin isn't in the path then the useradd and groupadd commands fail. Add the path to the commands.
Add /usr/sbin to the path inside the on_node_* scripts.

Resolves #161

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
