### PR TITLE
Add Rocky Linux 8 support for ParallelCluster

### DIFF
--- a/source/cdk/cdk_slurm_stack.py
+++ b/source/cdk/cdk_slurm_stack.py
@@ -309,6 +309,14 @@ class CdkSlurmStack(Stack):
                         self.mount_home_src = mount_dict['src']
                         logger.info(f"Mounting /home from {self.mount_home_src} on compute nodes")
 
+        if self.config['slurm']['ParallelClusterConfig']['Image']['Os'] == 'rocky8':
+            if not config_schema.PARALLEL_CLUSTER_SUPPORTS_CUSTOM_ROCKY_8(self.PARALLEL_CLUSTER_VERSION):
+                logger.error(f"rocky8 is not supported in ParallelCluster version {self.PARALLEL_CLUSTER_VERSION}. Support added in {PARALLEL_CLUSTER_SUPPORTS_CUSTOM_ROCKY_8_VERSION}.")
+                config_errors += 1
+            if 'CustomAmi' not in self.config['slurm']['ParallelClusterConfig']['Image']:
+                logger.error(f"Must specify config slurm/ParallelClusterConfig/Image/Os/CustomAmi with rocky8.")
+                config_errors += 1
+
         if 'Database' in self.config['slurm']['ParallelClusterConfig']:
             if 'DatabaseStackName' in self.config['slurm']['ParallelClusterConfig']['Database'] and 'EdaSlurmClusterStackName' in self.config['slurm']['ParallelClusterConfig']['Database']:
                 logger.error(f"Cannot specify both slurm/ParallelClusterConfig/Database/DatabaseStackName and slurm/ParallelClusterConfig/Database/EdaSlurmClusterStackName")
@@ -646,6 +654,13 @@ class CdkSlurmStack(Stack):
                 },
             }
         }
+        if config_schema.PARALLEL_CLUSTER_SUPPORTS_CUSTOM_ROCKY_8(self.PARALLEL_CLUSTER_VERSION):
+            ami_builds['Rocky'] = {
+                '8': {
+                    'arm64': {},
+                    'x86_64': {}
+                }
+            }
         template_vars['ComponentS3Url'] = self.custom_action_s3_urls['config/bin/configure-eda.sh']
         cfn_client = boto3.client('cloudformation', region_name=self.config['Region'])
         cfn_list_resources_paginator = cfn_client.get_paginator('list_stack_resources')
@@ -2163,6 +2178,9 @@ class CdkSlurmStack(Stack):
 
         if 'AllowedIps' in self.config['slurm']['ParallelClusterConfig']['Dcv']:
             self.parallel_cluster_config['HeadNode']['Dcv']['AllowedIps'] = self.config['slurm']['ParallelClusterConfig']['AllowedIps']
+
+        if self.munge_key_secret_arn:
+                self.parallel_cluster_config['Scheduling']['SlurmSettings']['MungeKeySecretArn'] = self.munge_key_secret_arn
 
         if 'CustomAmi' in self.config['slurm']['ParallelClusterConfig']['Image']:
             self.parallel_cluster_config['Image']['CustomAmi'] = self.config['slurm']['ParallelClusterConfig']['Image']['CustomAmi']

--- a/source/cdk/config_schema.py
+++ b/source/cdk/config_schema.py
@@ -61,13 +61,14 @@ logger.setLevel(logging.INFO)
 #     * Fix pmix CVE
 #     * Use Slurm 23.02.5
 MIN_PARALLEL_CLUSTER_VERSION = parse_version('3.6.0')
-DEFAULT_PARALLEL_CLUSTER_VERSION = parse_version('3.7.2')
+DEFAULT_PARALLEL_CLUSTER_VERSION = parse_version('3.8.0')
 PARALLEL_CLUSTER_VERSIONS = [
     '3.6.0',
     '3.6.1',
     '3.7.0',
     '3.7.1',
     '3.7.2',
+    '3.8.0',
 ]
 PARALLEL_CLUSTER_MUNGE_VERSIONS = {
     # This can be found on the head node at /opt/parallelcluster/sources
@@ -77,6 +78,7 @@ PARALLEL_CLUSTER_MUNGE_VERSIONS = {
     '3.7.0':   '0.5.15', # confirmed
     '3.7.1':   '0.5.15', # confirmed
     '3.7.2':   '0.5.15', # confirmed
+    '3.8.0':   '0.5.15', # confirmed
 }
 PARALLEL_CLUSTER_PYTHON_VERSIONS = {
     # This can be found on the head node at /opt/parallelcluster/pyenv/versions
@@ -85,6 +87,7 @@ PARALLEL_CLUSTER_PYTHON_VERSIONS = {
     '3.7.0':   '3.9.16', # confirmed
     '3.7.1':   '3.9.16', # confirmed
     '3.7.2':   '3.9.16', # confirmed
+    '3.8.0':   '3.9.17', # confirmed
 }
 PARALLEL_CLUSTER_SLURM_VERSIONS = {
     # This can be found on the head node at /etc/chef/local-mode-cache/cache/
@@ -93,6 +96,7 @@ PARALLEL_CLUSTER_SLURM_VERSIONS = {
     '3.7.0':   '23.02.4', # confirmed
     '3.7.1':   '23.02.5', # confirmed
     '3.7.2':   '23.02.6', # confirmed
+    '3.8.0':   '23.02.6', # confirmed
 }
 PARALLEL_CLUSTER_PC_SLURM_VERSIONS = {
     # This can be found on the head node at /etc/chef/local-mode-cache/cache/
@@ -101,6 +105,7 @@ PARALLEL_CLUSTER_PC_SLURM_VERSIONS = {
     '3.7.0':   '23-02-4-1', # confirmed
     '3.7.1':   '23-02-5-1', # confirmed
     '3.7.2':   '23-02-6-1', # confirmed
+    '3.8.0':   '23-02-6-1', # confirmed
 }
 SLURM_REST_API_VERSIONS = {
     '23-02-2-1': '0.0.39',
@@ -113,6 +118,7 @@ PARALLEL_CLUSTER_ALLOWED_OSES = [
     'alinux2',
     'centos7',
     'rhel8',
+    'rocky8',
     'ubuntu2004',
     'ubuntu2204'
     ]
@@ -155,12 +161,19 @@ PARALLEL_CLUSTER_SUPPORTS_MULTIPLE_INSTANCE_TYPES_PER_COMPUTE_RESOURCE_VERSION =
 def PARALLEL_CLUSTER_SUPPORTS_MULTIPLE_INSTANCE_TYPES_PER_COMPUTE_RESOURCE(parallel_cluster_version):
     return parallel_cluster_version >= PARALLEL_CLUSTER_SUPPORTS_MULTIPLE_INSTANCE_TYPES_PER_COMPUTE_RESOURCE_VERSION
 
-# Unsupported
-def PARALLEL_CLUSTER_SUPPORTS_CUSTOM_MUNGE_KEY(parallel_cluster_version):
-    return False
+# Version 3.8.0
 
+PARALLEL_CLUSTER_SUPPORTS_CUSTOM_ROCKY_8_VERSION = parse_version('3.8.0')
+def PARALLEL_CLUSTER_SUPPORTS_CUSTOM_ROCKY_8(parallel_cluster_version):
+    return parallel_cluster_version >= PARALLEL_CLUSTER_SUPPORTS_CUSTOM_ROCKY_8_VERSION
+
+PARALLEL_CLUSTER_SUPPORTS_CUSTOM_MUNGE_KEY_VERSION = parse_version('3.8.0')
+def PARALLEL_CLUSTER_SUPPORTS_CUSTOM_MUNGE_KEY(parallel_cluster_version):
+    return parallel_cluster_version >= PARALLEL_CLUSTER_SUPPORTS_CUSTOM_MUNGE_KEY_VERSION
+
+PARALLEL_CLUSTER_SUPPORTS_HOME_MOUNT_VERSION = parse_version('3.8.0')
 def PARALLEL_CLUSTER_SUPPORTS_HOME_MOUNT(parallel_cluster_version):
-    return False
+    return parallel_cluster_version >= PARALLEL_CLUSTER_SUPPORTS_HOME_MOUNT_VERSION
 
 # Determine all AWS regions available on the account.
 default_region = environ.get("AWS_DEFAULT_REGION", "us-east-1")

--- a/source/resources/lambdas/CreateParallelCluster/CreateParallelCluster.py
+++ b/source/resources/lambdas/CreateParallelCluster/CreateParallelCluster.py
@@ -126,7 +126,7 @@ def lambda_handler(event, context):
             valid_statuses = ['CREATE_COMPLETE', 'UPDATE_COMPLETE', 'UPDATE_ROLLBACK_COMPLETE']
             invalid_statuses = ['UPDATE_IN_PROGRESS', 'DELETE_IN_PROGRESS']
             if cluster_status in invalid_statuses:
-                cfnresponse.send(event, context, cfnresponse.FAILED, {f"{cluster_name} in {cluster_status} state."}, physicalResourceId=cluster_name)
+                cfnresponse.send(event, context, cfnresponse.FAILED, {'error': f"{cluster_name} in {cluster_status} state."}, physicalResourceId=cluster_name)
                 return
             if requestType == 'Create':
                 logger.info(f"{cluster_name} exists so changing request type from Create to Update.")
@@ -267,7 +267,7 @@ def lambda_handler(event, context):
                     break
                 if cluster_status == 'DELETE_FAILED':
                     logger.info(f"{cluster_name} delete failed")
-                    cfnresponse.send(event, context, cfnresponse.FAILED, {f"{cluster_name} in {cluster_status} state."}, physicalResourceId=cluster_name)
+                    cfnresponse.send(event, context, cfnresponse.FAILED, {'error': f"{cluster_name} in {cluster_status} state."}, physicalResourceId=cluster_name)
                     return
         else:
             raise ValueError(f"Unsupported requestType: {requestType}")

--- a/source/resources/parallel-cluster/config/bin/on_head_node_configured.sh
+++ b/source/resources/parallel-cluster/config/bin/on_head_node_configured.sh
@@ -54,6 +54,7 @@ export PATH=/usr/sbin:$PATH
 # Rerun on_head_node_start.sh to download latest versions of all config files and scripts
 $config_bin_dir/on_head_node_start.sh
 
+# This is handled directly by ParallelCluster starting in 3.8.0.
 if ! [ -z $MungeKeySecretId ]; then
     echo "Download munge key from $MungeKeySecretId"
     munge_key_b64=$(aws secretsmanager get-secret-value --secret-id $MungeKeySecretId --query 'SecretString' --output text)


### PR DESCRIPTION
Create image builder config files so can build custom Rocky 8 AMI.

Added rocky8 as an option for slurm/ParallelClusterConfig/Image/Os. Added config slurm/ParallelClusterConfig/Image/CustomAmi. Rocky 8 requires a custom AMI because PC doesn't supply one.

Add support for ParallelCluster munge key secret

Turn on debug of create accounts script
Allows easier debug if fails.

Fixed a bug in submitter /etc/fstab.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
