### PR TITLE
Fix bugs when creating slurmdb accounts for fair share

### DIFF
--- a/source/cdk/cdk_slurm_stack.py
+++ b/source/cdk/cdk_slurm_stack.py
@@ -517,13 +517,7 @@ class CdkSlurmStack(Stack):
                     'arm64': {},
                     'x86_64': {}
                 },
-            },
-            'Rocky': {
-                '8': {
-                    'arm64': {},
-                    'x86_64': {}
-                }
-            },
+            }
         }
         template_vars['ComponentS3Url'] = self.custom_action_s3_urls['config/bin/configure-eda.sh']
         cfn_client = boto3.client('cloudformation', region_name=self.config['Region'])

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/main.yml
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/main.yml
@@ -2,8 +2,8 @@
 
 - { include: config-users-groups.yml,    tags: users-groups }
 - { include: config-high-throughput.yml, tags: high-throughput }
-- { include: config-slurmdb-accounts.yml, tags: accouints }
-- { include: config-licenses.yml, tags: licenses }
-- { include: config-slurmrestd.yml, tags: slurmrestd }
-- { include: config-sshd.yml, tags: sshd }
 - { include: config-submitter-access.yml, tags: submitter }
+- { include: config-sshd.yml, tags: sshd }
+- { include: config-slurmrestd.yml, tags: slurmrestd }
+- { include: config-licenses.yml, tags: licenses }
+- { include: config-slurmdb-accounts.yml, tags: accounts }


### PR DESCRIPTION
Failures were causing ParallelCluster configuration to fail. Moved the ansible tasks to the end of the playbook. Make failures only send a notification to SNS instead of failing the playbook. This is important because the customer provided config file could have errors and it shouldn't cause ParallelCluster configuration to fail.

Don't create Rocky 8 build configurations before rocky8 is supported

Rocky 8 support will be added in ParallelCluster 3.8.0. Don't create rocky8 build configurations on earlier versions.

Resolves #167

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
