### PR TITLE
Fix submitter deconfigure update of /etc/fstab

### DIFF
--- a/source/resources/playbooks/roles/ParallelClusterSubmitterDeconfigure/tasks/main.yml
+++ b/source/resources/playbooks/roles/ParallelClusterSubmitterDeconfigure/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Remove /opt/slurm/{{ClusterName}} from /etc/fstab
   mount:
-    path: /opts/slurm/{{ClusterName}}
+    path: /opt/slurm/{{ClusterName}}
     backup: true
     fstype: nfs
     state: absent


### PR DESCRIPTION
When deconfiguring a cluster from the submitter, the slurm mount wasn't being removed from /etc/fstab.

Resolves #172 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
