### PR TITLE
Compile slurm for the os of the submitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site
 site/
 .vscode/
 source/resources/parallel-cluster/config/build-files/*/*/parallelcluster-*.yml
+security_scan/cfn_nag.log

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ local-docs: .mkdocs_venv/bin/activate
 github-docs: .mkdocs_venv/bin/activate
 	source .mkdocs_venv/bin/activate; mkdocs gh-deploy --strict
 
+security_scan:
+	security_scan/security_scan.sh
+
 test:
 	pytest -x -v tests
 

--- a/security_scan/security_scan.sh
+++ b/security_scan/security_scan.sh
@@ -5,9 +5,9 @@
 scriptdir=$(dirname $(readlink -f $0))
 
 cd $scriptdir/..
-./install.sh --config-file ~/slurm/slurm_eda_az1.yml --cdk-cmd synth
+./install.sh --config-file ~/slurm/res-eda/res-eda-pc-3-7-2-centos7-x86-config.yml --cdk-cmd synth
 
-cfn_nag_scan --input-path $scriptdir/../source/cdk.out/slurmedaaz1.template.json --deny-list-path $scriptdir/cfn_nag-deny-list.yml --fail-on-warnings &> $scriptdir/cfn_nag.log
+cfn_nag_scan --input-path $scriptdir/../source/cdk.out/res-eda-pc-3-7-2-centos7-x86-config.template.json --deny-list-path $scriptdir/cfn_nag-deny-list.yml --fail-on-warnings &> $scriptdir/cfn_nag.log
 
 cd $scriptdir
 if [ ! -e $scriptdir/bandit-env ]; then

--- a/source/cdk/cdk_slurm_stack.py
+++ b/source/cdk/cdk_slurm_stack.py
@@ -27,6 +27,7 @@ from aws_cdk import (
     aws_iam as iam,
     aws_kms as kms,
     aws_lambda as aws_lambda,
+    aws_lambda_event_sources as lambda_event_sources,
     aws_logs as logs,
     aws_opensearchservice as opensearch,
     aws_rds as rds,
@@ -51,24 +52,27 @@ from aws_cdk import (
 import base64
 import boto3
 from botocore.exceptions import ClientError
-from config_schema import get_PARALLEL_CLUSTER_MUNGE_VERSION, get_PARALLEL_CLUSTER_PYTHON_VERSION, get_SLURM_VERSION
+import config_schema
+from config_schema import get_PARALLEL_CLUSTER_MUNGE_VERSION, get_PARALLEL_CLUSTER_PYTHON_VERSION, get_PC_SLURM_VERSION, get_SLURM_VERSION
 from constructs import Construct
 from copy import copy, deepcopy
+from hashlib import sha512
 from jinja2 import Template as Template
 import json
 import logging
+import os
 from os import makedirs, path
 from os.path import dirname, realpath
 from packaging.version import parse as parse_version
 from pprint import PrettyPrinter
 import re
+from shutil import make_archive
 import subprocess
 from subprocess import check_output
 import sys
 from sys import exit
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
-from types import SimpleNamespace
 import yaml
 from yaml.scanner import ScannerError
 
@@ -124,9 +128,11 @@ class CdkSlurmStack(Stack):
 
         self.create_security_groups()
 
-        self.create_parallel_cluster_lambdas()
-
+        # Assets needs ARNs of topics used to trigger Lambdas so must be declared as part of assets
         self.create_parallel_cluster_assets()
+
+        # Lambdas need ARNs from assets in IAM permissions
+        self.create_parallel_cluster_lambdas()
 
         self.create_parallel_cluster_config()
 
@@ -288,10 +294,20 @@ class CdkSlurmStack(Stack):
 
         self.PARALLEL_CLUSTER_VERSION = parse_version(self.config['slurm']['ParallelClusterConfig']['Version'])
 
-        if self.PARALLEL_CLUSTER_VERSION < parse_version('3.7.0'):
+        if not config_schema.PARALLEL_CLUSTER_SUPPORTS_LOGIN_NODES(self.PARALLEL_CLUSTER_VERSION):
             if 'LoginNodes' in self.config['slurm']['ParallelClusterConfig']:
-                logger.error(f"slurm/ParallelClusterConfig/LoginNodes not supported before version 3.7.0")
+                logger.error(f"slurm/ParallelClusterConfig/LoginNodes not supported before version {config_schema.PARALLEL_CLUSTER_SUPPORTS_LOGIN_NODES_VERSION}")
                 config_errors += 1
+
+        self.mount_home = False
+        if not config_schema.PARALLEL_CLUSTER_SUPPORTS_HOME_MOUNT(self.PARALLEL_CLUSTER_VERSION):
+            if 'storage' in self.config['slurm']:
+                for mount_dict in self.config['slurm']['storage']['ExtraMounts']:
+                    logger.info(f"mount_dict={mount_dict}")
+                    if mount_dict['dest'] == '/home':
+                        self.mount_home = True
+                        self.mount_home_src = mount_dict['src']
+                        logger.info(f"Mounting /home from {self.mount_home_src} on compute nodes")
 
         if 'Database' in self.config['slurm']['ParallelClusterConfig']:
             if 'DatabaseStackName' in self.config['slurm']['ParallelClusterConfig']['Database'] and 'EdaSlurmClusterStackName' in self.config['slurm']['ParallelClusterConfig']['Database']:
@@ -422,55 +438,164 @@ class CdkSlurmStack(Stack):
         self.config = validated_config
 
     def create_parallel_cluster_assets(self):
+        # Create a secure hash of all of the assets so that changes can be easily detected to trigger cluster updates.
+        self.assets_hash = sha512()
+
         self.parallel_cluster_asset_read_policy = iam.ManagedPolicy(
             self, "ParallelClusterAssetReadPolicy",
             path = '/parallelcluster/',
-            managed_policy_name = f"{self.stack_name}-ParallelClusterAssetReadPolicy",
+            #managed_policy_name = f"{self.stack_name}-ParallelClusterAssetReadPolicy",
         )
+        # If use managed_policy_name, then get the following cfn_nag warning.
+        # W28: Resource found with an explicit name, this disallows updates that require replacement of this resource
 
-        self.parallel_cluster_jwt_write_policy = iam.ManagedPolicy(
-            self, "ParallelClusterJwtWritePolicy",
-            managed_policy_name = f"{self.stack_name}-ParallelClusterJwtWritePolicy",
-        )
-        self.jwt_token_for_root_ssm_parameter.grant_write(self.parallel_cluster_jwt_write_policy)
-        self.jwt_token_for_slurmrestd_ssm_parameter.grant_write(self.parallel_cluster_jwt_write_policy)
+        self.create_munge_key_secret()
 
         self.playbooks_asset = s3_assets.Asset(self, 'Playbooks',
             path = 'resources/playbooks',
             follow_symlinks = SymlinkFollowMode.ALWAYS
         )
         self.playbooks_asset.grant_read(self.parallel_cluster_asset_read_policy)
-        self.playbooks_s3_url = self.playbooks_asset.s3_object_url
+        self.playbooks_asset_bucket = self.playbooks_asset.s3_bucket_name
+        self.playbooks_asset_key    = self.playbooks_asset.s3_object_key
 
         self.assets_bucket = self.playbooks_asset.s3_bucket_name
         self.assets_base_key = self.config['slurm']['ClusterName']
 
+        self.parallel_cluster_config_json_s3_key = f"{self.assets_base_key}/ParallelClusterConfig.json"
+        self.parallel_cluster_config_yaml_s3_key = f"{self.assets_base_key}/ParallelClusterConfig.yml"
+
         self.parallel_cluster_munge_key_write_policy = iam.ManagedPolicy(
             self, "ParallelClusterMungeKeyWritePolicy",
-            managed_policy_name = f"{self.stack_name}-ParallelClusterMungeKeyWritePolicy",
+            #managed_policy_name = f"{self.stack_name}-ParallelClusterMungeKeyWritePolicy",
             statements = [
                 iam.PolicyStatement(
                     effect=iam.Effect.ALLOW,
                     actions=[
                         's3:PutObject',
                     ],
-                    resources=[f"arn:aws:s3:::{self.assets_bucket}/{self.config['slurm']['ClusterName']}/config/munge.key"]
+                    resources=[f"arn:{Aws.PARTITION}:s3:::{self.assets_bucket}/{self.config['slurm']['ClusterName']}/config/munge.key"]
                 )
             ]
         )
+        # If use managed_policy_name, then get the following cfn_nag warning.
+        # W28: Resource found with an explicit name, this disallows updates that require replacement of this resource
+
+        self.parallel_cluster_sns_publish_policy = iam.ManagedPolicy(
+            self, "ParallelClusterSnsPublishPolicy",
+            path = '/parallelcluster/',
+            #managed_policy_name = f"{self.stack_name}-ParallelClusterSnspublishPolicy",
+        )
+
+        if 'ErrorSnsTopicArn' in self.config:
+            self.error_sns_topic = sns.Topic.from_topic_arn(
+                self, 'ErrorSnsTopic',
+                topic_arn = self.config['ErrorSnsTopicArn']
+            )
+            self.error_sns_topic.grant_publish(self.parallel_cluster_sns_publish_policy)
+
+        # SNS topic that gets notified when cluster is created and triggers a lambda to create the head nodes's A record
+        self.create_head_node_a_record_sns_topic = sns.Topic(
+            self, "CreateHeadNodeARecordSnsTopic",
+            topic_name = f"{self.config['slurm']['ClusterName']}CreateHeadNodeARecord"
+            )
+        # W47:SNS Topic should specify KmsMasterKeyId property
+        self.suppress_cfn_nag(self.create_head_node_a_record_sns_topic, 'W47', 'Use default KMS key.')
+        if 'RESEnvironmentName' in self.config:
+            # SNS topic that gets notified when cluster is created and triggers a lambda to configure the cluster manager
+            self.configure_cluster_manager_sns_topic = sns.Topic(
+                self, "ConfigureClusterManagerSnsTopic",
+                topic_name = f"{self.config['slurm']['ClusterName']}ConfigureClusterManager"
+                )
+            # W47:SNS Topic should specify KmsMasterKeyId property
+            self.suppress_cfn_nag(self.configure_cluster_manager_sns_topic, 'W47', 'Use default KMS key.')
+            # SNS topic that gets notified when cluster is created and triggers a lambda to configure the cluster manager
+            self.configure_submitters_sns_topic = sns.Topic(
+                self, "ConfigureSubmittersSnsTopic",
+                topic_name = f"{self.config['slurm']['ClusterName']}ConfigureSubmitters"
+                )
+            # W47:SNS Topic should specify KmsMasterKeyId property
+            self.suppress_cfn_nag(self.configure_submitters_sns_topic, 'W47', 'Use default KMS key.')
+
+        # Create an SSM parameter to store the JWT tokens for root and slurmrestd
+        self.jwt_token_for_root_ssm_parameter_name = f"/{self.config['slurm']['ClusterName']}/slurmrestd/jwt/root"
+        self.jwt_token_for_root_ssm_parameter = ssm.StringParameter(
+            self, f"JwtTokenForRootParameter",
+            parameter_name = self.jwt_token_for_root_ssm_parameter_name,
+            string_value = 'None'
+        )
+        self.jwt_token_for_slurmrestd_ssm_parameter_name = f"/{self.config['slurm']['ClusterName']}/slurmrestd/jwt/slurmrestd"
+        self.jwt_token_for_slurmrestd_ssm_parameter = ssm.StringParameter(
+            self, f"JwtTokenForSlurmrestdParameter",
+            parameter_name = self.jwt_token_for_slurmrestd_ssm_parameter_name,
+            string_value = 'None'
+        )
 
         s3_client = boto3.client('s3', region_name=self.cluster_region)
+
+        # The asset isn't uploaded right away so create our own zipfile and upload it
+        playbooks_zipfile_base_filename = f"/tmp/{self.config['slurm']['ClusterName']}_playbooks"
+        playbooks_zipfile_filename = playbooks_zipfile_base_filename + '.zip'
+        make_archive(playbooks_zipfile_base_filename, 'zip', 'resources/playbooks')
+        self.playbooks_bucket = self.playbooks_asset_bucket
+        self.playbooks_key = f"{self.assets_base_key}/playbooks.zip"
+        self.playbooks_s3_url = f"s3://{self.playbooks_bucket}/{self.playbooks_key}"
+        with open(playbooks_zipfile_filename, 'rb') as playbooks_zipfile_fh:
+            self.assets_hash.update(playbooks_zipfile_fh.read())
+        with open(playbooks_zipfile_filename, 'rb') as playbooks_zipfile_fh:
+            s3_client.put_object(
+                Bucket = self.assets_bucket,
+                Key    = self.playbooks_key,
+                Body   = playbooks_zipfile_fh
+            )
+        os.remove(playbooks_zipfile_filename)
+
+        self.configure_cluster_manager_sns_topic_arn_parameter_name = f"/{self.config['slurm']['ClusterName']}/ConfigureClusterManagerSnsTopicArn"
+        self.configure_cluster_manager_sns_topic_arn_parameter = ssm.StringParameter(
+            self, f"ConfigureClusterManagerSnsTopicArnParameter",
+            parameter_name = self.configure_cluster_manager_sns_topic_arn_parameter_name,
+            string_value = self.configure_cluster_manager_sns_topic.topic_arn
+        )
+        self.configure_cluster_manager_sns_topic_arn_parameter.grant_read(self.parallel_cluster_asset_read_policy)
+
+        self.configure_submitters_sns_topic_arn_parameter_name = f"/{self.config['slurm']['ClusterName']}/ConfigureSubmittersSnsTopicArn"
+        self.configure_submitters_sns_topic_arn_parameter = ssm.StringParameter(
+            self, f"ConfigureSubmittersSnsTopicArnParameter",
+            parameter_name = self.configure_submitters_sns_topic_arn_parameter_name,
+            string_value = self.configure_submitters_sns_topic.topic_arn
+        )
+        self.configure_submitters_sns_topic_arn_parameter.grant_read(self.parallel_cluster_asset_read_policy)
+
+        self.create_head_node_a_record_sns_topic_arn_parameter_name = f"/{self.config['slurm']['ClusterName']}/CreateHeadNodeARecordSnsTopicArn"
+        self.create_head_node_a_record_sns_topic_arn_parameter = ssm.StringParameter(
+            self, f"CreateHeadNodeARecordSnsTopicArnParameter",
+            parameter_name = self.create_head_node_a_record_sns_topic_arn_parameter_name,
+            string_value = self.create_head_node_a_record_sns_topic.topic_arn
+        )
+        self.create_head_node_a_record_sns_topic_arn_parameter.grant_read(self.parallel_cluster_asset_read_policy)
 
         template_vars = {
             'assets_bucket': self.assets_bucket,
             'assets_base_key': self.assets_base_key,
             'ClusterName': self.config['slurm']['ClusterName'],
+            'ConfigureClusterManagerSnsTopicArnParameter': self.configure_cluster_manager_sns_topic_arn_parameter_name,
+            'ConfigureSubmittersSnsTopicArnParameter': self.configure_submitters_sns_topic_arn_parameter_name,
+            'CreateHeadNodeARecordSnsTopicArnParameter': self.create_head_node_a_record_sns_topic_arn_parameter_name,
             'ErrorSnsTopicArn': self.config.get('ErrorSnsTopicArn', ''),
             'playbooks_s3_url': self.playbooks_s3_url,
             'Region': self.cluster_region,
             'SubnetId': self.config['SubnetId'],
             'SubmitterSlurmConfigDir': f"/opt/slurm/{self.config['slurm']['ClusterName']}/config"
         }
+        if config_schema.PARALLEL_CLUSTER_SUPPORTS_CUSTOM_MUNGE_KEY(self.PARALLEL_CLUSTER_VERSION):
+            template_vars['MungeKeySecretId'] = ''
+        else:
+            template_vars['MungeKeySecretId'] = self.config['slurm'].get('MungeKeySecret', '')
+        if self.mount_home and not config_schema.PARALLEL_CLUSTER_SUPPORTS_HOME_MOUNT(self.PARALLEL_CLUSTER_VERSION):
+            template_vars['HomeMountSrc'] = self.mount_home_src
+        else:
+            template_vars['HomeMountSrc'] = ''
+
         # Additions or deletions to the list should be reflected in config_scripts in on_head_node_start.sh.
         files_to_upload = [
             'config/bin/configure-eda.sh',
@@ -500,6 +625,7 @@ class CdkSlurmStack(Stack):
                 Key    = s3_key,
                 Body   = local_file_content
             )
+            self.assets_hash.update(bytes(local_file_content, 'utf-8'))
 
         ami_builds = {
             'amzn': {
@@ -568,6 +694,7 @@ class CdkSlurmStack(Stack):
                         Key    = f"{self.assets_base_key}/config/build-files/{template_vars['ImageName']}.yml",
                         Body   = build_file_content
                     )
+                    self.assets_hash.update(bytes(build_file_content, 'utf-8'))
                     fh = open(f"{build_files_path}/{template_vars['ImageName']}.yml", 'w')
                     fh.write(build_file_content)
 
@@ -584,6 +711,7 @@ class CdkSlurmStack(Stack):
                         Key    = f"{self.assets_base_key}/config/build-files/{template_vars['ImageName']}.yml",
                         Body   = build_file_content
                     )
+                    self.assets_hash.update(bytes(build_file_content, 'utf-8'))
                     fh = open(f"{build_files_path}/{template_vars['ImageName']}.yml", 'w')
                     fh.write(build_file_content)
 
@@ -599,6 +727,8 @@ class CdkSlurmStack(Stack):
             local_file,
             self.assets_bucket,
             s3_key)
+        with open(local_file, 'rb') as fh:
+            self.assets_hash.update(fh.read())
 
         ansible_compute_node_template_vars = self.get_instance_template_vars('ParallelClusterComputeNode')
         fh = NamedTemporaryFile('w', delete=False)
@@ -612,6 +742,8 @@ class CdkSlurmStack(Stack):
             local_file,
             self.assets_bucket,
             s3_key)
+        with open(local_file, 'rb') as fh:
+            self.assets_hash.update(fh.read())
 
         ansible_submitter_template_vars = self.get_instance_template_vars('ParallelClusterSubmitter')
         fh = NamedTemporaryFile('w', delete=False)
@@ -625,8 +757,8 @@ class CdkSlurmStack(Stack):
             local_file,
             self.assets_bucket,
             s3_key)
-
-        self.create_munge_ssm_parameter()
+        with open(local_file, 'rb') as fh:
+            self.assets_hash.update(fh.read())
 
     def get_image_builder_parent_image(self, distribution, version, architecture):
         filters = [
@@ -869,14 +1001,89 @@ class CdkSlurmStack(Stack):
             handler="CreateParallelCluster.lambda_handler",
             code=aws_lambda.Code.from_bucket(createParallelClusterLambdaAsset.bucket, createParallelClusterLambdaAsset.s3_object_key),
             layers=[self.parallel_cluster_lambda_layer],
-            vpc = self.vpc,
-            allow_all_outbound = True
         )
         self.create_parallel_cluster_lambda.add_to_role_policy(
             statement=iam.PolicyStatement(
                 effect=iam.Effect.ALLOW,
                 actions=[
-                    's3:*',
+                    's3:DeleteObject',
+                    's3:GetObject',
+                    's3:PutObject'
+                ],
+                resources=[
+                    f"arn:{Aws.PARTITION}:s3:::{self.assets_bucket}/{self.config['slurm']['ClusterName']}/*",
+                    f"arn:{Aws.PARTITION}:s3:::{self.assets_bucket}/{self.config['slurm']['ClusterName']}/{self.parallel_cluster_config_json_s3_key}"
+                    ]
+                )
+            )
+        # From https://docs.aws.amazon.com/parallelcluster/latest/ug/iam-roles-in-parallelcluster-v3.html#iam-roles-in-parallelcluster-v3-base-user-policy
+        self.create_parallel_cluster_lambda.add_to_role_policy(
+            statement=iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "cloudformation:*",
+                    "cloudwatch:DeleteAlarms",
+                    "cloudwatch:DeleteDashboards",
+                    "cloudwatch:DescribeAlarms",
+                    "cloudwatch:GetDashboard",
+                    "cloudwatch:ListDashboards",
+                    "cloudwatch:PutDashboard",
+                    "cloudwatch:PutCompositeAlarm",
+                    "cloudwatch:PutMetricAlarm",
+                    'ec2:AllocateAddress',
+                    'ec2:AssociateAddress',
+                    'ec2:AttachNetworkInterface',
+                    'ec2:AuthorizeSecurityGroupEgress',
+                    'ec2:AuthorizeSecurityGroupIngress',
+                    'ec2:CreateFleet',
+                    'ec2:CreateLaunchTemplate',
+                    'ec2:CreateLaunchTemplateVersion',
+                    'ec2:CreateNetworkInterface',
+                    'ec2:CreatePlacementGroup',
+                    'ec2:CreateSecurityGroup',
+                    'ec2:CreateSnapshot',
+                    'ec2:CreateTags',
+                    'ec2:CreateVolume',
+                    'ec2:DeleteLaunchTemplate',
+                    'ec2:DeleteNetworkInterface',
+                    'ec2:DeletePlacementGroup',
+                    'ec2:DeleteSecurityGroup',
+                    'ec2:DeleteVolume',
+                    'ec2:Describe*',
+                    'ec2:DisassociateAddress',
+                    'ec2:ModifyLaunchTemplate',
+                    'ec2:ModifyNetworkInterfaceAttribute',
+                    'ec2:ModifyVolume',
+                    'ec2:ModifyVolumeAttribute',
+                    'ec2:ReleaseAddress',
+                    'ec2:RevokeSecurityGroupEgress',
+                    'ec2:RevokeSecurityGroupIngress',
+                    'ec2:RunInstances',
+                    'ec2:TerminateInstances',
+                    "fsx:DescribeFileCaches",
+                    "logs:DeleteLogGroup",
+                    "logs:PutRetentionPolicy",
+                    "logs:DescribeLogGroups",
+                    "logs:CreateLogGroup",
+                    "logs:TagResource",
+                    "logs:UntagResource",
+                    "logs:FilterLogEvents",
+                    "logs:GetLogEvents",
+                    "logs:CreateExportTask",
+                    "logs:DescribeLogStreams",
+                    "logs:DescribeExportTasks",
+                    "logs:DescribeMetricFilters",
+                    "logs:PutMetricFilter",
+                    "logs:DeleteMetricFilter",
+                    "resource-groups:ListGroupResources",
+                    "route53:ChangeResourceRecordSets",
+                    "route53:ChangeTagsForResource",
+                    "route53:CreateHostedZone",
+                    "route53:DeleteHostedZone",
+                    "route53:GetChange",
+                    "route53:GetHostedZone",
+                    "route53:ListResourceRecordSets",
+                    "route53:ListQueryLoggingConfigs",
                 ],
                 resources=['*']
                 )
@@ -885,11 +1092,345 @@ class CdkSlurmStack(Stack):
             statement=iam.PolicyStatement(
                 effect=iam.Effect.ALLOW,
                 actions=[
-                    '*',
+                    'dynamodb:DescribeTable',
+                    'dynamodb:ListTagsOfResource',
+                    'dynamodb:CreateTable',
+                    'dynamodb:DeleteTable',
+                    'dynamodb:GetItem',
+                    'dynamodb:PutItem',
+                    'dynamodb:UpdateItem',
+                    'dynamodb:Query',
+                    'dynamodb:TagResource'
+                ],
+                resources=[f"arn:{Aws.PARTITION}:dynamodb:*:{Aws.ACCOUNT_ID}:table/parallelcluster-*"]
+                )
+            )
+        self.create_parallel_cluster_lambda.add_to_role_policy(
+            statement=iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "iam:GetRole",
+                    "iam:GetRolePolicy",
+                    "iam:GetPolicy",
+                    "iam:SimulatePrincipalPolicy",
+                    "iam:GetInstanceProfile"
+                ],
+                resources=[
+                    f"arn:{Aws.PARTITION}:iam::{Aws.ACCOUNT_ID}:role/*",
+                    f"arn:{Aws.PARTITION}:iam::{Aws.ACCOUNT_ID}:policy/*",
+                    f"arn:{Aws.PARTITION}:iam::aws:policy/*",
+                    f"arn:{Aws.PARTITION}:iam::{Aws.ACCOUNT_ID}:instance-profile/*"
+                    ]
+                )
+            )
+        self.create_parallel_cluster_lambda.add_to_role_policy(
+            statement=iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "iam:CreateInstanceProfile",
+                    "iam:DeleteInstanceProfile",
+                    "iam:AddRoleToInstanceProfile",
+                    "iam:RemoveRoleFromInstanceProfile"
+                ],
+                resources=[f"arn:{Aws.PARTITION}:iam::{Aws.ACCOUNT_ID}:instance-profile/parallelcluster/*"]
+                )
+            )
+        self.create_parallel_cluster_lambda.add_to_role_policy(
+            statement=iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "iam:PassRole"
+                ],
+                resources=[
+                    f"arn:{Aws.PARTITION}:iam::{Aws.ACCOUNT_ID}:role/parallelcluster/*"
+                    ]
+                )
+                # "Condition": {
+                #     "StringEqualsIfExists": {
+                #         "iam:PassedToService": [
+                #             "lambda.amazonaws.com",
+                #             "ec2.amazonaws.com",
+                #             "spotfleet.amazonaws.com"
+                #         ]
+                #     }
+                #  },
+            )
+        self.create_parallel_cluster_lambda.add_to_role_policy(
+            statement=iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "lambda:CreateFunction",
+                    "lambda:DeleteFunction",
+                    "lambda:GetFunctionConfiguration",
+                    "lambda:GetFunction",
+                    "lambda:InvokeFunction",
+                    "lambda:AddPermission",
+                    "lambda:RemovePermission",
+                    "lambda:UpdateFunctionConfiguration",
+                    "lambda:TagResource",
+                    "lambda:ListTags",
+                    "lambda:UntagResource"
+                ],
+                resources=[
+                    f"arn:{Aws.PARTITION}:lambda:*:{Aws.ACCOUNT_ID}:function:parallelcluster-*",
+                    f"arn:{Aws.PARTITION}:lambda:*:{Aws.ACCOUNT_ID}:function:pcluster-*"
+                    ]
+                )
+            )
+        self.create_parallel_cluster_lambda.add_to_role_policy(
+            statement=iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "s3:*"
+                ],
+                resources=[
+                    f"arn:{Aws.PARTITION}:s3:::parallelcluster-*",
+                    f"arn:{Aws.PARTITION}:s3:::aws-parallelcluster-*"
+                    ]
+                )
+            )
+        self.create_parallel_cluster_lambda.add_to_role_policy(
+            statement=iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "s3:Get*",
+                    "s3:List*"
+                ],
+                resources=[f"arn:{Aws.PARTITION}:s3:::*-aws-parallelcluster*"]
+                )
+            )
+        self.create_parallel_cluster_lambda.add_to_role_policy(
+            statement=iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "elasticfilesystem:*"
+                ],
+                resources=[
+                    f"arn:{Aws.PARTITION}:elasticfilesystem:*:{Aws.ACCOUNT_ID}:*"
+                    ]
+                )
+            )
+        self.create_parallel_cluster_lambda.add_to_role_policy(
+            statement=iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "secretsmanager:DescribeSecret"
+                ],
+                resources=[f"arn:{Aws.PARTITION}:secretsmanager:{self.config['Region']}:{Aws.ACCOUNT_ID}:secret:*"]
+                )
+            )
+        # https://docs.aws.amazon.com/parallelcluster/latest/ug/iam-roles-in-parallelcluster-v3.html#iam-roles-in-parallelcluster-v3-user-policy-manage-iam
+        # From Privileged IAM access mode
+        self.create_parallel_cluster_lambda.add_to_role_policy(
+            statement=iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    "iam:AttachRolePolicy",
+                    "iam:CreateRole",
+                    "iam:CreateServiceLinkedRole",
+                    "iam:DeleteRole",
+                    "iam:DeleteRolePolicy",
+                    "iam:DetachRolePolicy",
+                    "iam:PutRolePolicy",
+                    "iam:TagRole",
+                ],
+                resources=[
+                    f"arn:{Aws.PARTITION}:iam::{Aws.ACCOUNT_ID}:role/parallelcluster/*"
+                    ]
+                )
+            )
+
+        createHeadNodeARecordAsset = s3_assets.Asset(self, "CreateHeadNodeARecordAsset", path="resources/lambdas/CreateHeadNodeARecord")
+        self.create_head_node_a_record_lambda = aws_lambda.Function(
+            self, "CreateHeadNodeARecordLambda",
+            function_name=f"{self.stack_name}-CreateHeadNodeARecord",
+            description="Create head node A record",
+            memory_size=2048,
+            runtime=aws_lambda.Runtime.PYTHON_3_9,
+            architecture=aws_lambda.Architecture.X86_64,
+            timeout=Duration.minutes(15),
+            log_retention=logs.RetentionDays.INFINITE,
+            handler="CreateHeadNodeARecord.lambda_handler",
+            code=aws_lambda.Code.from_bucket(createHeadNodeARecordAsset.bucket, createHeadNodeARecordAsset.s3_object_key),
+            environment = {
+                'ClusterName': self.config['slurm']['ClusterName'],
+                'Region': self.cluster_region
+            }
+        )
+        self.create_head_node_a_record_lambda.add_to_role_policy(
+            statement=iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    'ec2:DescribeInstances',
+                    'route53:ChangeResourceRecordSets',
+                    'route53:ListHostedZones',
+                    'route53:ListResourceRecordSets',
                 ],
                 resources=['*']
                 )
             )
+        self.create_head_node_a_record_lambda.add_event_source(
+            lambda_event_sources.SnsEventSource(self.create_head_node_a_record_sns_topic)
+        )
+        self.create_head_node_a_record_sns_topic.grant_publish(self.parallel_cluster_sns_publish_policy)
+
+        updateHeadNodeLambdaAsset = s3_assets.Asset(self, "UpdateHeadNodeAsset", path="resources/lambdas/UpdateHeadNode")
+        self.update_head_node_lambda = aws_lambda.Function(
+            self, "UpdateHeadNodeLambda",
+            function_name=f"{self.stack_name}-UpdateHeadNode",
+            description="Update head node",
+            memory_size=2048,
+            runtime=aws_lambda.Runtime.PYTHON_3_9,
+            architecture=aws_lambda.Architecture.X86_64,
+            timeout=Duration.minutes(15),
+            log_retention=logs.RetentionDays.INFINITE,
+            handler="UpdateHeadNode.lambda_handler",
+            code=aws_lambda.Code.from_bucket(updateHeadNodeLambdaAsset.bucket, updateHeadNodeLambdaAsset.s3_object_key),
+            environment = {
+                'ClusterName': self.config['slurm']['ClusterName'],
+                'Region': self.cluster_region
+            }
+        )
+        self.update_head_node_lambda.add_to_role_policy(
+            statement=iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                actions=[
+                    'ec2:DescribeInstances',
+                    'ssm:GetCommandInvocation',
+                    'ssm:SendCommand',
+                ],
+                resources=['*']
+                )
+            )
+
+        if 'RESEnvironmentName' in self.config:
+            configureClusterManagerLambdaAsset = s3_assets.Asset(self, "ConfigureClusterManagerAsset", path="resources/lambdas/ConfigureClusterManager")
+            self.configure_cluster_manager_lambda = aws_lambda.Function(
+                self, "ConfigureClusterManagerLambda",
+                function_name=f"{self.stack_name}-ConfigureClusterManager",
+                description="Configure RES cluster manager",
+                memory_size=2048,
+                runtime=aws_lambda.Runtime.PYTHON_3_9,
+                architecture=aws_lambda.Architecture.X86_64,
+                timeout=Duration.minutes(15),
+                log_retention=logs.RetentionDays.INFINITE,
+                handler="ConfigureClusterManager.lambda_handler",
+                code=aws_lambda.Code.from_bucket(configureClusterManagerLambdaAsset.bucket, configureClusterManagerLambdaAsset.s3_object_key),
+                environment = {
+                    'ClusterName': self.config['slurm']['ClusterName'],
+                    'Region': self.cluster_region,
+                    'RESEnvironmentName': self.config['RESEnvironmentName']
+                }
+            )
+            self.configure_cluster_manager_lambda.add_to_role_policy(
+                statement=iam.PolicyStatement(
+                    effect=iam.Effect.ALLOW,
+                    actions=[
+                        'ec2:DescribeInstances',
+                        'ssm:GetCommandInvocation',
+                        'ssm:SendCommand',
+                    ],
+                    resources=['*']
+                    )
+                )
+            self.configure_cluster_manager_lambda.add_event_source(
+                lambda_event_sources.SnsEventSource(self.configure_cluster_manager_sns_topic)
+            )
+            self.configure_cluster_manager_sns_topic.grant_publish(self.parallel_cluster_sns_publish_policy)
+
+            configureSubmittersLambdaAsset = s3_assets.Asset(self, "ConfigureSubmittersAsset", path="resources/lambdas/ConfigureSubmitters")
+            self.configure_submitters_lambda = aws_lambda.Function(
+                self, "ConfigureSubmittersLambda",
+                function_name=f"{self.stack_name}-ConfigureSubmitters",
+                description="Configure submitters",
+                memory_size=2048,
+                runtime=aws_lambda.Runtime.PYTHON_3_9,
+                architecture=aws_lambda.Architecture.X86_64,
+                timeout=Duration.minutes(15),
+                log_retention=logs.RetentionDays.INFINITE,
+                handler="ConfigureSubmitters.lambda_handler",
+                code=aws_lambda.Code.from_bucket(configureSubmittersLambdaAsset.bucket, configureSubmittersLambdaAsset.s3_object_key),
+                environment = {
+                    'Region': self.cluster_region,
+                    'ClusterName': self.config['slurm']['ClusterName'],
+                    'RESEnvironmentName': self.config['RESEnvironmentName']
+                }
+            )
+            self.configure_submitters_lambda.add_to_role_policy(
+                statement=iam.PolicyStatement(
+                    effect=iam.Effect.ALLOW,
+                    actions=[
+                        'ec2:DescribeInstances',
+                        'ssm:GetCommandInvocation',
+                        'ssm:SendCommand',
+                    ],
+                    resources=['*']
+                    )
+                )
+            self.configure_submitters_lambda.add_event_source(
+                lambda_event_sources.SnsEventSource(self.configure_submitters_sns_topic)
+            )
+            self.configure_submitters_sns_topic.grant_publish(self.parallel_cluster_sns_publish_policy)
+
+            self.deconfigureClusterManagerLambdaAsset = s3_assets.Asset(self, "DeconfigureClusterManagerAsset", path="resources/lambdas/DeconfigureClusterManager")
+            self.deconfigure_cluster_manager_lambda = aws_lambda.Function(
+                self, "DeconfigureClusterManagerLambda",
+                function_name=f"{self.stack_name}-DeconfigureClusterManager",
+                description="Deconfigure RES cluster manager",
+                memory_size=2048,
+                runtime=aws_lambda.Runtime.PYTHON_3_9,
+                architecture=aws_lambda.Architecture.X86_64,
+                timeout=Duration.minutes(15),
+                log_retention=logs.RetentionDays.INFINITE,
+                handler="DeconfigureClusterManager.lambda_handler",
+                code=aws_lambda.Code.from_bucket(self.deconfigureClusterManagerLambdaAsset.bucket, self.deconfigureClusterManagerLambdaAsset.s3_object_key),
+                environment = {
+                    'ClusterName': self.config['slurm']['ClusterName'],
+                    'Region': self.cluster_region,
+                    'RESEnvironmentName': self.config['RESEnvironmentName']
+                }
+            )
+            self.deconfigure_cluster_manager_lambda.add_to_role_policy(
+                statement=iam.PolicyStatement(
+                    effect=iam.Effect.ALLOW,
+                    actions=[
+                        'ec2:DescribeInstances',
+                        'ssm:GetCommandInvocation',
+                        'ssm:SendCommand',
+                    ],
+                    resources=['*']
+                    )
+                )
+
+            deconfigureSubmittersLambdaAsset = s3_assets.Asset(self, "DeconfigureSubmittersAsset", path="resources/lambdas/DeconfigureSubmitters")
+            self.deconfigure_submitters_lambda = aws_lambda.Function(
+                self, "DeconfigureSubmittersLambda",
+                function_name=f"{self.stack_name}-DeconfigureSubmitters",
+                description="Deconfigure submitters",
+                memory_size=2048,
+                runtime=aws_lambda.Runtime.PYTHON_3_9,
+                architecture=aws_lambda.Architecture.X86_64,
+                timeout=Duration.minutes(15),
+                log_retention=logs.RetentionDays.INFINITE,
+                handler="DeconfigureSubmitters.lambda_handler",
+                code=aws_lambda.Code.from_bucket(deconfigureSubmittersLambdaAsset.bucket, deconfigureSubmittersLambdaAsset.s3_object_key),
+                environment = {
+                    'ClusterName': self.config['slurm']['ClusterName'],
+                    'Region': self.cluster_region,
+                    'RESEnvironmentName': self.config['RESEnvironmentName']
+                }
+            )
+            self.deconfigure_submitters_lambda.add_to_role_policy(
+                statement=iam.PolicyStatement(
+                    effect=iam.Effect.ALLOW,
+                    actions=[
+                        'ec2:DescribeInstances',
+                        'ssm:GetCommandInvocation',
+                        'ssm:SendCommand',
+                    ],
+                    resources=['*']
+                    )
+                )
 
     def create_callSlurmRestApiLambda(self):
         callSlurmRestApiLambdaAsset = s3_assets.Asset(self, "CallSlurmRestApiLambdaAsset", path="resources/lambdas/CallSlurmRestApi")
@@ -914,24 +1455,19 @@ class CdkSlurmStack(Stack):
                 }
         )
 
-        # Create an SSM parameter to store the JWT tokens for root and slurmrestd
-        self.jwt_token_for_root_ssm_parameter_name = f"/{self.config['slurm']['ClusterName']}/slurmrestd/jwt/root"
-        self.jwt_token_for_root_ssm_parameter = ssm.StringParameter(
-            self, f"JwtTokenForRootParameter",
-            parameter_name = self.jwt_token_for_root_ssm_parameter_name,
-            string_value = 'None'
-        )
         self.jwt_token_for_root_ssm_parameter.grant_read(self.call_slurm_rest_api_lambda)
 
-        self.jwt_token_for_slurmrestd_ssm_parameter_name = f"/{self.config['slurm']['ClusterName']}/slurmrestd/jwt/slurmrestd"
-        self.jwt_token_for_slurmrestd_ssm_parameter = ssm.StringParameter(
-            self, f"JwtTokenForSlurmrestdParameter",
-            parameter_name = self.jwt_token_for_slurmrestd_ssm_parameter_name,
-            string_value = 'None'
-        )
         self.jwt_token_for_slurmrestd_ssm_parameter.grant_read(self.call_slurm_rest_api_lambda)
 
+        self.parallel_cluster_jwt_write_policy = iam.ManagedPolicy(
+            self, "ParallelClusterJwtWritePolicy",
+            #managed_policy_name = f"{self.stack_name}-ParallelClusterJwtWritePolicy",
+        )
+        self.jwt_token_for_root_ssm_parameter.grant_write(self.parallel_cluster_jwt_write_policy)
+        self.jwt_token_for_slurmrestd_ssm_parameter.grant_write(self.parallel_cluster_jwt_write_policy)
+
     def create_security_groups(self):
+        self.NFS_PORT = 2049
         self.slurmctld_port_min = 6820
         self.slurmctld_port_max = 6829
         self.slurmctld_port = '6820-6829'
@@ -941,6 +1477,10 @@ class CdkSlurmStack(Stack):
 
         self.imagebuilder_sg = ec2.SecurityGroup(self, "ImageBuilderSG", vpc=self.vpc, allow_all_outbound=True, description="ImageBuilder Security Group")
         Tags.of(self.imagebuilder_sg).add("Name", f"{self.stack_name}-ImageBuilderSG")
+        # W5:Security Groups found with cidr open to world on egress
+        self.suppress_cfn_nag(self.imagebuilder_sg, 'W5', 'All outbound allowed.')
+        # W40:Security Groups egress with an IpProtocol of -1 found
+        self.suppress_cfn_nag(self.imagebuilder_sg, 'W40', 'All outbound allowed.')
 
         self.nfs_sg = ec2.SecurityGroup(self, "NfsSG", vpc=self.vpc, allow_all_outbound=False, description="Nfs Security Group")
         Tags.of(self.nfs_sg).add("Name", f"{self.stack_name}-NfsSG")
@@ -949,7 +1489,11 @@ class CdkSlurmStack(Stack):
         # FSxZ requires all output access
         self.zfs_sg = ec2.SecurityGroup(self, "ZfsSG", vpc=self.vpc, allow_all_outbound=True, description="Zfs Security Group")
         Tags.of(self.zfs_sg).add("Name", f"{self.stack_name}-ZfsSG")
-        self.suppress_cfn_nag(self.zfs_sg, 'W29', 'Egress port range used to block all egress')
+        # W5:Security Groups found with cidr open to world on egress
+        self.suppress_cfn_nag(self.zfs_sg, 'W5', 'FSxZ requires all egress access.')
+        # W40:Security Groups egress with an IpProtocol of -1 found
+        self.suppress_cfn_nag(self.zfs_sg, 'W40', 'FSxZ requires all egress access.')
+        #self.suppress_cfn_nag(self.zfs_sg, 'W29', 'Egress port range used to block all egress')
 
         # Compute nodes may use lustre file systems so create a security group with the required ports.
         self.lustre_sg = ec2.SecurityGroup(self, "LustreSG", vpc=self.vpc, allow_all_outbound=False, description="Lustre Security Group")
@@ -1056,20 +1600,20 @@ class CdkSlurmStack(Stack):
         if self.slurmdbd_sg and 'ExistingSlurmDbd' not in self.config['slurm']:
             fs_client_sgs['SlurmDbd'] = self.slurmdbd_sg
         for fs_client_sg_name, fs_client_sg in fs_client_sgs.items():
-            fs_client_sg.connections.allow_to(self.nfs_sg, ec2.Port.tcp(2049), f"{fs_client_sg_name} to Nfs")
+            fs_client_sg.connections.allow_to(self.nfs_sg, ec2.Port.tcp(self.NFS_PORT), f"{fs_client_sg_name} to Nfs")
         if self.onprem_cidr:
-            self.nfs_sg.connections.allow_from(self.onprem_cidr, ec2.Port.tcp(2049), 'OnPremNodes to Nfs')
+            self.nfs_sg.connections.allow_from(self.onprem_cidr, ec2.Port.tcp(self.NFS_PORT), 'OnPremNodes to Nfs')
         # Allow compute nodes in remote regions access to NFS
         for compute_region, compute_region_cidr in self.remote_compute_regions.items():
-            self.nfs_sg.connections.allow_from(ec2.Peer.ipv4(compute_region_cidr), ec2.Port.tcp(2049), f"{compute_region} to Nfs")
+            self.nfs_sg.connections.allow_from(ec2.Peer.ipv4(compute_region_cidr), ec2.Port.tcp(self.NFS_PORT), f"{compute_region} to Nfs")
 
         # ZFS Connections
         # https://docs.aws.amazon.com/fsx/latest/OpenZFSGuide/limit-access-security-groups.html
         for fs_client_sg_name, fs_client_sg in fs_client_sgs.items():
             fs_client_sg.connections.allow_to(self.zfs_sg, ec2.Port.tcp(111), f"{fs_client_sg_name} to Zfs")
             fs_client_sg.connections.allow_to(self.zfs_sg, ec2.Port.udp(111), f"{fs_client_sg_name} to Zfs")
-            fs_client_sg.connections.allow_to(self.zfs_sg, ec2.Port.tcp(2049), f"{fs_client_sg_name} to Zfs")
-            fs_client_sg.connections.allow_to(self.zfs_sg, ec2.Port.udp(2049), f"{fs_client_sg_name} to Zfs")
+            fs_client_sg.connections.allow_to(self.zfs_sg, ec2.Port.tcp(self.NFS_PORT), f"{fs_client_sg_name} to Zfs")
+            fs_client_sg.connections.allow_to(self.zfs_sg, ec2.Port.udp(self.NFS_PORT), f"{fs_client_sg_name} to Zfs")
             fs_client_sg.connections.allow_to(self.zfs_sg, ec2.Port.tcp_range(20001, 20003), f"{fs_client_sg_name} to Zfs")
             fs_client_sg.connections.allow_to(self.zfs_sg, ec2.Port.udp_range(20001, 20003), f"{fs_client_sg_name} to Zfs")
             self.suppress_cfn_nag(fs_client_sg, 'W27', 'Correct, restricted range for zfs: 20001-20003')
@@ -1078,8 +1622,8 @@ class CdkSlurmStack(Stack):
         if self.onprem_cidr:
             self.zfs_sg.connections.allow_from(self.onprem_cidr, ec2.Port.tcp(111), 'OnPremNodes to Zfs')
             self.zfs_sg.connections.allow_from(self.onprem_cidr, ec2.Port.udp(111), 'OnPremNodes to Zfs')
-            self.zfs_sg.connections.allow_from(self.onprem_cidr, ec2.Port.tcp(2049), 'OnPremNodes to Zfs')
-            self.zfs_sg.connections.allow_from(self.onprem_cidr, ec2.Port.udp(2049), 'OnPremNodes to Zfs')
+            self.zfs_sg.connections.allow_from(self.onprem_cidr, ec2.Port.tcp(self.NFS_PORT), 'OnPremNodes to Zfs')
+            self.zfs_sg.connections.allow_from(self.onprem_cidr, ec2.Port.udp(self.NFS_PORT), 'OnPremNodes to Zfs')
             self.zfs_sg.connections.allow_from(self.onprem_cidr, ec2.Port.tcp_range(20001, 20003), 'OnPremNodes to Zfs')
             self.zfs_sg.connections.allow_from(self.onprem_cidr, ec2.Port.udp_range(20001, 20003), 'OnPremNodes to Zfs')
             self.suppress_cfn_nag(self.zfs_sg, 'W27', 'Correct, restricted range for zfs: 20001-20003')
@@ -1088,8 +1632,8 @@ class CdkSlurmStack(Stack):
         for compute_region, compute_region_cidr in self.remote_compute_regions.items():
             self.zfs_sg.connections.allow_from(ec2.Peer.ipv4(compute_region_cidr), ec2.Port.tcp(111), f"{compute_region} to Zfs")
             self.zfs_sg.connections.allow_from(ec2.Peer.ipv4(compute_region_cidr), ec2.Port.udp(111), f"{compute_region} to Zfs")
-            self.zfs_sg.connections.allow_from(ec2.Peer.ipv4(compute_region_cidr), ec2.Port.tcp(2049), f"{compute_region} to Zfs")
-            self.zfs_sg.connections.allow_from(ec2.Peer.ipv4(compute_region_cidr), ec2.Port.udp(2049), f"{compute_region} to Zfs")
+            self.zfs_sg.connections.allow_from(ec2.Peer.ipv4(compute_region_cidr), ec2.Port.tcp(self.NFS_PORT), f"{compute_region} to Zfs")
+            self.zfs_sg.connections.allow_from(ec2.Peer.ipv4(compute_region_cidr), ec2.Port.udp(self.NFS_PORT), f"{compute_region} to Zfs")
             self.zfs_sg.connections.allow_from(ec2.Peer.ipv4(compute_region_cidr), ec2.Port.tcp_range(20001, 20003), f"{compute_region} to Zfs")
             self.zfs_sg.connections.allow_from(ec2.Peer.ipv4(compute_region_cidr), ec2.Port.udp_range(20001, 20003), f"{compute_region} to Zfs")
 
@@ -1121,11 +1665,11 @@ class CdkSlurmStack(Stack):
         for fs_type in self.extra_mount_security_groups.keys():
             for extra_mount_sg_name, extra_mount_sg in self.extra_mount_security_groups[fs_type].items():
                 if fs_type in ['nfs', 'zfs']:
-                    self.slurmnode_sg.connections.allow_to(extra_mount_sg, ec2.Port.tcp(2049), f"SlurmNode to {extra_mount_sg_name} - Nfs")
+                    self.slurmnode_sg.connections.allow_to(extra_mount_sg, ec2.Port.tcp(self.NFS_PORT), f"SlurmNode to {extra_mount_sg_name} - Nfs")
                     if fs_type == 'zfs':
                         self.slurmnode_sg.connections.allow_to(extra_mount_sg, ec2.Port.tcp(111), f"SlurmNode to {extra_mount_sg_name} - Zfs")
                         self.slurmnode_sg.connections.allow_to(extra_mount_sg, ec2.Port.udp(111), f"SlurmNode to {extra_mount_sg_name} - Zfs")
-                        self.slurmnode_sg.connections.allow_to(extra_mount_sg, ec2.Port.udp(2049), f"SlurmNode to {extra_mount_sg_name} - Zfs")
+                        self.slurmnode_sg.connections.allow_to(extra_mount_sg, ec2.Port.udp(self.NFS_PORT), f"SlurmNode to {extra_mount_sg_name} - Zfs")
                         self.slurmnode_sg.connections.allow_to(extra_mount_sg, ec2.Port.tcp_range(20001, 20003), f"SlurmNode to {extra_mount_sg_name} - Zfs")
                         self.slurmnode_sg.connections.allow_to(extra_mount_sg, ec2.Port.udp_range(20001, 20003), f"SlurmNode to {extra_mount_sg_name} - Zfs")
                         self.suppress_cfn_nag(self.slurmnode_sg, 'W27', 'Correct, restricted range for zfs: 20001-20003')
@@ -1220,6 +1764,7 @@ class CdkSlurmStack(Stack):
         # slurm submitter connections
         # egress
         for slurm_submitter_sg_name, slurm_submitter_sg in self.submitter_security_groups.items():
+            slurm_submitter_sg.connections.allow_to(self.slurmctl_sg, ec2.Port.tcp(self.NFS_PORT), f"{slurm_submitter_sg_name} to {self.slurmctl_sg_name} - NFS")
             slurm_submitter_sg.connections.allow_to(self.slurmctl_sg, ec2.Port.tcp_range(self.slurmctld_port_min, self.slurmctld_port_max), f"{slurm_submitter_sg_name} to {self.slurmctl_sg_name}")
             slurm_submitter_sg.connections.allow_to(self.slurmnode_sg, ec2.Port.tcp(self.slurmd_port), f"{slurm_submitter_sg_name} to {self.slurmnode_sg_name} - srun")
             if self.slurmdbd_sg:
@@ -1229,6 +1774,8 @@ class CdkSlurmStack(Stack):
                 slurm_submitter_sg.connections.allow_to(self.onprem_cidr, ec2.Port.tcp(self.slurmd_port), f"{slurm_submitter_sg_name} to OnPremNodes - srun")
             for compute_region, compute_region_cidr in self.remote_compute_regions.items():
                 slurm_submitter_sg.connections.allow_to(ec2.Peer.ipv4(compute_region_cidr), ec2.Port.tcp(self.slurmd_port), f"{slurm_submitter_sg_name} to {compute_region} - srun")
+            # W29:Security Groups found egress with port range instead of just a single port
+            self.suppress_cfn_nag(self.slurmnode_sg, 'W29', 'Port range ok. Submitter to SlurmCtl requires range for slurmctld ports')
 
         # Try to suppress cfn_nag warnings on ingress/egress rules
         for slurm_submitter_sg_name, slurm_submitter_sg in self.submitter_security_groups.items():
@@ -1262,10 +1809,9 @@ class CdkSlurmStack(Stack):
             instance_template_vars['FileSystemMountPath'] = '/opt/slurm'
             instance_template_vars['ParallelClusterVersion'] = self.config['slurm']['ParallelClusterConfig']['Version']
             instance_template_vars['SlurmBaseDir'] = '/opt/slurm'
-            instance_template_vars['SlurmOSDir'] = '/opt/slurm'
-            instance_template_vars['SlurmVersion'] =  get_SLURM_VERSION(self.config)
 
         if instance_role == 'ParallelClusterHeadNode':
+            instance_template_vars['PCSlurmVersion'] =  get_PC_SLURM_VERSION(self.config)
             if 'Database' in self.config['slurm']['ParallelClusterConfig']:
                 instance_template_vars['AccountingStorageHost'] = 'pcvluster-head-node'
             else:
@@ -1284,10 +1830,16 @@ class CdkSlurmStack(Stack):
             instance_template_vars['SlurmrestdSocket'] = f"{instance_template_vars['SlurmrestdSocketDir']}/slurmrestd.socket"
             instance_template_vars['SlurmrestdUid'] = self.config['slurm']['SlurmCtl']['SlurmrestdUid']
         elif instance_role == 'ParallelClusterSubmitter':
-            instance_template_vars['FileSystemMountPath'] = f'/opt/slurm/{cluster_name}'
+            instance_template_vars['SlurmVersion']                = get_SLURM_VERSION(self.config)
             instance_template_vars['ParallelClusterMungeVersion'] = get_PARALLEL_CLUSTER_MUNGE_VERSION(self.config)
-            instance_template_vars['SlurmBaseDir'] = f'/opt/slurm/{cluster_name}'
-            instance_template_vars['SlurmOSDir'] = f'/opt/slurm/{cluster_name}'
+            instance_template_vars['SlurmrestdPort']        = self.slurmrestd_port
+            instance_template_vars['FileSystemMountPath']   = f'/opt/slurm/{cluster_name}'
+            instance_template_vars['SlurmBaseDir']          = f'/opt/slurm/{cluster_name}'
+            instance_template_vars['SubmitterSlurmBaseDir'] = f'/opt/slurm/{cluster_name}'
+            instance_template_vars['SlurmConfigDir']        = f'/opt/slurm/{cluster_name}/config'
+            instance_template_vars['SlurmSrcDir']           = f'/opt/slurm/{cluster_name}/config/src'
+            instance_template_vars['SlurmEtcDir']           = f'/opt/slurm/{cluster_name}/etc'
+            instance_template_vars['ModulefilesBaseDir']    = f'/opt/slurm/{cluster_name}/config/modules/modulefiles'
 
         elif instance_role == 'ParallelClusterComputeNode':
             pass
@@ -1296,32 +1848,46 @@ class CdkSlurmStack(Stack):
 
         return instance_template_vars
 
-    def create_munge_ssm_parameter(self):
-        ssm_client = boto3.client('ssm', region_name=self.cluster_region)
-        response = ssm_client.describe_parameters(
-            ParameterFilters = [
-                {
-                    'Key': 'Name',
-                    'Option': 'Equals',
-                    'Values': [self.config['slurm']['MungeKeySsmParameter']]
-                }
-            ]
-        )['Parameters']
-        if response:
-            logger.info(f"{self.config['slurm']['MungeKeySsmParameter']} SSM parameter exists and will be used.")
-            self.munge_key_ssm_parameter = ssm.StringParameter.from_string_parameter_name(
-                self, f"MungeKeySsmParamter",
-                string_parameter_name  = f"{self.config['slurm']['MungeKeySsmParameter']}"
+    def create_munge_key_secret(self):
+        self.munge_key_secret_arn = None
+        if 'MungeKeySecret' not in self.config['slurm']:
+            return
+
+        # Check to see if secret exists
+        # Use it if it exists, otherwise create a new secret
+        secretsmanager_client = boto3.client('secretsmanager', region_name=self.cluster_region)
+        try:
+            response = secretsmanager_client.get_secret_value(
+                SecretId = self.config['slurm']['MungeKeySecret']
             )
-        else:
-            logger.info(f"{self.config['slurm']['MungeKeySsmParameter']} SSM parameter doesn't exist. Creating it so can give IAM permissions to it.")
+            self.munge_key_secret_arn = response['ARN']
+            secret_string = response['SecretString']
+            logger.info(f"Munge key secret exists and will be used: {secret_string} length={len(secret_string)}")
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ResourceNotFoundException':
+                logger.info(f"MungeKeySecret {self.config['slurm']['MungeKeySecret']} doesn't exist so creating for you.")
+            else:
+                logger.exception("Error getting MungeKeySecret {self.config['slurm']['MungeKeySecret']}")
+
+        if not self.munge_key_secret_arn:
+            logger.info(f"{self.config['slurm']['MungeKeySecret']} doesn't exist so creating it. This isn't a stack resource and will not be deleted with the stack.")
             output = check_output(['dd if=/dev/random bs=1 count=1024 | base64 -w 0'], shell=True, stderr=subprocess.DEVNULL, encoding='utf8', errors='ignore')
             munge_key = output.split('\n')[0]
-            self.munge_key_ssm_parameter = ssm.StringParameter(
-                self, f"MungeKeySsmParamter",
-                parameter_name  = f"{self.config['slurm']['MungeKeySsmParameter']}",
-                string_value = f"{munge_key}"
+            secretsmanager_client.create_secret(
+                Name = self.config['slurm']['MungeKeySecret'],
+                SecretString = munge_key
             )
+            self.munge_key_secret_arn = secretsmanager_client.get_secret_value(
+                SecretId = self.config['slurm']['MungeKeySecret']
+            )['ARN']
+
+        if self.munge_key_secret_arn:
+            self.munge_key_secret = secretsmanager.Secret.from_secret_complete_arn(
+                self, 'MungeKeySecret',
+                secret_complete_arn = self.munge_key_secret_arn
+            )
+            self.munge_key_secret.grant_read(self.parallel_cluster_asset_read_policy)
+            logger.info(f"Munge key secret arn: {self.munge_key_secret_arn}")
 
     def create_fault_injection_templates(self):
         self.fis_spot_termination_role = iam.Role(
@@ -1363,6 +1929,8 @@ class CdkSlurmStack(Stack):
             "FISLogGroup",
             retention = logs.RetentionDays.TEN_YEARS
             )
+        # W84: CloudWatchLogs LogGroup should specify a KMS Key Id to encrypt the log data
+        self.suppress_cfn_nag(fis_log_group, 'W84', 'Use default KMS key.')
         fis_log_group.grant_write(self.fis_spot_termination_role)
         fis_log_configuration = fis.CfnExperimentTemplate.ExperimentTemplateLogConfigurationProperty(
             log_schema_version = 1,
@@ -1468,19 +2036,15 @@ class CdkSlurmStack(Stack):
     def create_parallel_cluster_config(self):
         MAX_NUMBER_OF_QUEUES = 50
         MAX_NUMBER_OF_COMPUTE_RESOURCES = 50
-        if self.PARALLEL_CLUSTER_VERSION < parse_version('3.7.0'):
-            # ParallelCluster has a restriction where a queue can have only 1 instance type with memory based scheduling
-            # So, for now creating a queue for each instance type and purchase option
-            PARALLEL_CLUSTER_SUPPORTS_MULTIPLE_COMPUTE_RESOURCES_PER_QUEUE = False
-            PARALLEL_CLUSTER_SUPPORTS_MULTIPLE_INSTANCE_TYPES_PER_COMPUTE_RESOURCE = False
-        else:
-            PARALLEL_CLUSTER_SUPPORTS_MULTIPLE_COMPUTE_RESOURCES_PER_QUEUE = True
-            PARALLEL_CLUSTER_SUPPORTS_MULTIPLE_INSTANCE_TYPES_PER_COMPUTE_RESOURCE = True
 
         # Check the architecture of the ComputeNodeAmi
         if 'ComputeNodeAmi' in self.config['slurm']['ParallelClusterConfig']:
             compute_node_ami = self.config['slurm']['ParallelClusterConfig']['ComputeNodeAmi']
-            ami_info = self.ec2_client.describe_images(ImageIds=[compute_node_ami])['Images'][0]
+            images_info = self.ec2_client.describe_images(ImageIds=[compute_node_ami])['Images']
+            if not images_info:
+                logger.error(f"ComputeNodeAmi({compute_node_ami}) doesn't exist.")
+                exit(1)
+            ami_info = images_info[0]
             ami_architecture = ami_info['Architecture']
             cluster_architecture = self.config['slurm']['ParallelClusterConfig']['Architecture']
             if ami_architecture != cluster_architecture:
@@ -1497,6 +2061,7 @@ class CdkSlurmStack(Stack):
                     'AdditionalIamPolicies': [
                         {'Policy': 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'},
                         {'Policy': self.parallel_cluster_asset_read_policy.managed_policy_arn},
+                        {'Policy': self.parallel_cluster_sns_publish_policy.managed_policy_arn},
                         {'Policy': self.parallel_cluster_jwt_write_policy.managed_policy_arn},
                         {'Policy': self.parallel_cluster_munge_key_write_policy.managed_policy_arn},
                     ],
@@ -1650,13 +2215,13 @@ class CdkSlurmStack(Stack):
         for cores in sorted(instance_types_by_core_memory):
             logger.info(f"        {cores} core(s)")
             for mem_gb in instance_types_by_core_memory[cores]:
-                logger.info(f"            {len(instance_types_by_core_memory[cores][mem_gb])} instance type with {mem_gb} GB")
+                logger.info(f"            {len(instance_types_by_core_memory[cores][mem_gb])} instance type with {mem_gb:4} GB: {instance_types_by_core_memory[cores][mem_gb]}")
         logger.info("Instance type by memory and core:")
         logger.info(f"    {len(instance_types_by_memory_core)} unique memory size:")
         for mem_gb in sorted(instance_types_by_memory_core):
             logger.info(f"        {mem_gb} GB")
             for cores in sorted(instance_types_by_memory_core[mem_gb]):
-                logger.info(f"            {len(instance_types_by_memory_core[mem_gb][cores])} instance type with {cores} core(s)")
+                logger.info(f"            {len(instance_types_by_memory_core[mem_gb][cores])} instance type with {cores:3} core(s): {instance_types_by_memory_core[mem_gb][cores]}")
 
         purchase_options = ['ONDEMAND']
         if self.config['slurm']['InstanceConfig']['UseSpot']:
@@ -1665,12 +2230,13 @@ class CdkSlurmStack(Stack):
         nodesets = {}
         number_of_queues = 0
         number_of_compute_resources = 0
-        if PARALLEL_CLUSTER_SUPPORTS_MULTIPLE_COMPUTE_RESOURCES_PER_QUEUE and PARALLEL_CLUSTER_SUPPORTS_MULTIPLE_INSTANCE_TYPES_PER_COMPUTE_RESOURCE:
+        for purchase_option in purchase_options:
+            nodesets[purchase_option] = []
+        if config_schema.PARALLEL_CLUSTER_SUPPORTS_MULTIPLE_COMPUTE_RESOURCES_PER_QUEUE(self.PARALLEL_CLUSTER_VERSION) and config_schema.PARALLEL_CLUSTER_SUPPORTS_MULTIPLE_COMPUTE_RESOURCES_PER_QUEUE(self.PARALLEL_CLUSTER_VERSION):
             # Creating a queue for each memory size
-            # In each queue, create a CR for each permutation of memmory and core count
-            for purchase_option in purchase_options:
-                nodesets[purchase_option] = []
-                for mem_gb in sorted(instance_types_by_memory_core.keys()):
+            # In each queue, create a CR for each permutation of memory and core count
+            for mem_gb in sorted(instance_types_by_memory_core.keys()):
+                for purchase_option in purchase_options:
                     if purchase_option == 'ONDEMAND':
                         queue_name_prefix = "od"
                         allocation_strategy = 'lowest-price'
@@ -1684,6 +2250,7 @@ class CdkSlurmStack(Stack):
                     if number_of_compute_resources >= MAX_NUMBER_OF_COMPUTE_RESOURCES:
                         logger.warning(f"Skipping {queue_name} queue because MAX_NUMBER_OF_COMPUTE_RESOURCES=={MAX_NUMBER_OF_COMPUTE_RESOURCES}")
                         continue
+                    logger.info(f"Configuring {queue_name} queue:")
                     nodeset = f"{queue_name}_nodes"
                     nodesets[purchase_option].append(nodeset)
                     parallel_cluster_queue = {
@@ -1720,6 +2287,7 @@ class CdkSlurmStack(Stack):
                             'AdditionalIamPolicies': [
                                 {'Policy': 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'},
                                 {'Policy': self.parallel_cluster_asset_read_policy.managed_policy_arn},
+                                {'Policy': self.parallel_cluster_sns_publish_policy.managed_policy_arn}
                             ]
                         },
                         'Networking': {
@@ -1741,13 +2309,16 @@ class CdkSlurmStack(Stack):
 
                     for num_cores in sorted(instance_types_by_memory_core[mem_gb].keys()):
                         compute_resource_name = f"{queue_name_prefix}-{mem_gb}gb-{num_cores}-cores"
+                        instance_types = sorted(instance_types_by_memory_core[mem_gb][num_cores])
+                        # If we do multiple CRs per queue then we hit the CR limit without being able to create queues for all memory sizes.
+                        # Select the instance types with the lowest core count for higher memory/core ratio and lower cost.
                         if len(parallel_cluster_queue['ComputeResources']):
-                            logger.warning(f"Skipping {compute_resource_name} compute resource to reduce the number of compute resources to 1 per queue")
+                            logger.info(f"    Skipping {compute_resource_name:18} compute resource: {instance_types} to reduce number of CRs.")
                             continue
                         if number_of_compute_resources >= MAX_NUMBER_OF_COMPUTE_RESOURCES:
-                            logger.warning(f"Skipping {compute_resource_name} compute resource because MAX_NUMBER_OF_COMPUTE_RESOURCES=={MAX_NUMBER_OF_COMPUTE_RESOURCES}")
+                            logger.warning(f" Skipping {compute_resource_name:18} compute resource: {instance_types} because MAX_NUMBER_OF_COMPUTE_RESOURCES=={MAX_NUMBER_OF_COMPUTE_RESOURCES}")
                             continue
-                        instance_types = sorted(instance_types_by_memory_core[mem_gb][num_cores])
+                        logger.info(f"    Adding   {compute_resource_name:18} compute resource: {instance_types}")
                         if compute_resource_name in self.config['slurm']['InstanceConfig']['NodeCounts']['ComputeResourceCounts']:
                             min_count = self.config['slurm']['InstanceConfig']['NodeCounts']['ComputeResourceCounts'][compute_resource_name]['MinCount']
                             max_count = self.config['slurm']['InstanceConfig']['NodeCounts']['ComputeResourceCounts'][compute_resource_name]['MaxCount']
@@ -1794,8 +2365,9 @@ class CdkSlurmStack(Stack):
                         number_of_compute_resources += 1
                     self.parallel_cluster_config['Scheduling']['SlurmQueues'].append(parallel_cluster_queue)
         else:
+            # ParallelCluster has a restriction where a queue can have only 1 instance type with memory based scheduling
+            # So, for now creating a queue for each instance type and purchase option
             for purchase_option in purchase_options:
-                nodesets[purchase_option] = []
                 for instance_type in self.instance_types:
                     efa_supported = self.plugin.get_EfaSupported(self.cluster_region, instance_type) and self.config['slurm']['ParallelClusterConfig']['EnableEfa']
                     if purchase_option == 'ONDEMAND':
@@ -1844,6 +2416,7 @@ class CdkSlurmStack(Stack):
                             'AdditionalIamPolicies': [
                                 {'Policy': 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'},
                                 {'Policy': self.parallel_cluster_asset_read_policy.managed_policy_arn},
+                                {'Policy': self.parallel_cluster_sns_publish_policy.managed_policy_arn}
                             ]
                         },
                         'Networking': {
@@ -2008,6 +2581,8 @@ class CdkSlurmStack(Stack):
         self.parallel_cluster_config['SharedStorage'] = []
         for extra_mount_dict in self.config['slurm'].get('storage', {}).get('ExtraMounts', {}):
             mount_dir = extra_mount_dict['dest']
+            if mount_dir == '/home' and not config_schema.PARALLEL_CLUSTER_SUPPORTS_HOME_MOUNT(self.PARALLEL_CLUSTER_VERSION):
+                continue
             storage_type = extra_mount_dict['StorageType']
             if storage_type == 'Efs':
                 parallel_cluster_storage_dict = {
@@ -2039,13 +2614,11 @@ class CdkSlurmStack(Stack):
                 }
             self.parallel_cluster_config['SharedStorage'].append(parallel_cluster_storage_dict)
 
-        self.parallel_cluster_config_json_s3_key = f"{self.assets_base_key}/ParallelClusterConfig.json"
-        self.parallel_cluster_config_yaml_s3_key = f"{self.assets_base_key}/ParallelClusterConfig.yml"
-
         self.parallel_cluster = CustomResource(
             self, "ParallelCluster",
             service_token = self.create_parallel_cluster_lambda.function_arn,
             properties = {
+                'ParallelClusterConfigHash': self.assets_hash.hexdigest(),
                 'ParallelClusterConfigJson': json.dumps(self.parallel_cluster_config, sort_keys=False),
                 'ParallelClusterConfigS3Bucket': self.assets_bucket,
                 'ParallelClusterConfigJsonS3Key': self.parallel_cluster_config_json_s3_key,
@@ -2056,6 +2629,43 @@ class CdkSlurmStack(Stack):
         )
         self.parallel_cluster_config_json_s3_url = self.parallel_cluster.get_att_string('ConfigJsonS3Url')
         self.parallel_cluster_config_yaml_s3_url = self.parallel_cluster.get_att_string('ConfigYamlS3Url')
+        # The lambda to create an A record for the head node must be built before the parallel cluster.
+        self.parallel_cluster.node.add_dependency(self.create_head_node_a_record_lambda)
+        self.parallel_cluster.node.add_dependency(self.update_head_node_lambda)
+        # The lambdas to configure instances must exist befor the cluster so they can be called.
+        self.parallel_cluster.node.add_dependency(self.configure_cluster_manager_lambda)
+        self.parallel_cluster.node.add_dependency(self.configure_submitters_lambda)
+
+        self.call_slurm_rest_api_lambda.node.add_dependency(self.parallel_cluster)
+
+        # Custom resource to update the head node anytime the assets_hash changes
+        self.update_head_node = CustomResource(
+            self, "UpdateHeadNode",
+            service_token = self.update_head_node_lambda.function_arn,
+            properties = {
+                'ParallelClusterConfigHash': self.assets_hash.hexdigest(),
+            }
+        )
+        self.update_head_node.node.add_dependency(self.parallel_cluster)
+
+        if 'RESEnvironmentName' in self.config:
+            # Custom resource to deconfigure cluster manager before deleting cluster
+            self.deconfigure_cluster_manager = CustomResource(
+                self, "DeconfigureClusterManager",
+                service_token = self.deconfigure_cluster_manager_lambda.function_arn,
+                properties = {
+                }
+            )
+            self.deconfigure_cluster_manager.node.add_dependency(self.parallel_cluster)
+
+            # Custom resource to deconfigure submitters before deleting cluster
+            self.deconfigure_submitters = CustomResource(
+                self, "DeconfigureSubmitters",
+                service_token = self.deconfigure_submitters_lambda.function_arn,
+                properties = {
+                }
+            )
+            self.deconfigure_submitters.node.add_dependency(self.parallel_cluster)
 
         CfnOutput(self, "ParallelClusterConfigJsonS3Url",
             value = self.parallel_cluster_config_json_s3_url
@@ -2063,19 +2673,13 @@ class CdkSlurmStack(Stack):
         CfnOutput(self, "ParallelClusterConfigYamlS3Url",
             value = self.parallel_cluster_config_yaml_s3_url
         )
-        CfnOutput(self, "MungeParameterName",
-            value = self.munge_key_ssm_parameter.parameter_name
-        )
-        CfnOutput(self, "MungeParameterArn",
-            value = self.munge_key_ssm_parameter.parameter_arn
-        )
         CfnOutput(self, "PlaybookS3Url",
             value = self.playbooks_asset.s3_object_url
         )
         region = self.cluster_region
         cluster_name = self.config['slurm']['ClusterName']
         CfnOutput(self, "Command01_SubmitterMountHeadNode",
-            value = f"head_ip=$(aws ec2 describe-instances --region {region} --filters 'Name=tag:parallelcluster:cluster-name,Values={cluster_name}' 'Name=tag:parallelcluster:node-type,Values=HeadNode' --query 'Reservations[0].Instances[0].PrivateIpAddress' --output text) && sudo mkdir -p /opt/slurm/{cluster_name} && sudo mount $head_ip:/opt/slurm /opt/slurm/{cluster_name}"
+            value = f"head_ip=head_node.{self.config['slurm']['ClusterName']}.pcluster && sudo mkdir -p /opt/slurm/{cluster_name} && sudo mount $head_ip:/opt/slurm /opt/slurm/{cluster_name}"
         )
         CfnOutput(self, "Command02_CreateUsersGroupsJsonConfigure",
             value = f"sudo /opt/slurm/{cluster_name}/config/bin/create_users_groups_json_configure.sh"

--- a/source/resources/lambdas/ConfigureClusterManager/ConfigureClusterManager.py
+++ b/source/resources/lambdas/ConfigureClusterManager/ConfigureClusterManager.py
@@ -1,0 +1,84 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+'''
+Call /opt/slurm/{{ClusterName}}/config/bin/create_users_groups_json_configure.sh using ssm run command.
+'''
+import boto3
+import json
+import logging
+from os import environ as environ
+
+logger=logging.getLogger(__file__)
+logger_formatter = logging.Formatter('%(levelname)s: %(message)s')
+logger_streamHandler = logging.StreamHandler()
+logger_streamHandler.setFormatter(logger_formatter)
+logger.addHandler(logger_streamHandler)
+logger.setLevel(logging.INFO)
+logger.propagate = False
+
+def lambda_handler(event, context):
+    try:
+        logger.info(f"event:\n{json.dumps(event, indent=4)}")
+
+        cluster_name = environ['ClusterName']
+        cluster_region = environ['Region']
+        environment_name = environ['RESEnvironmentName']
+        logger.info(f"Update RES cluster={environment_name} manager for {cluster_name} in {cluster_region}")
+
+        ec2_client = boto3.client('ec2', region_name=cluster_region)
+
+        cluster_manager_info = ec2_client.describe_instances(
+            Filters = [
+                {'Name': 'tag:res:EnvironmentName', 'Values': [environment_name]},
+                {'Name': 'tag:res:ModuleId', 'Values': ['cluster-manager']}
+            ]
+        )['Reservations'][0]['Instances'][0]
+        cluster_manager_instance_id = cluster_manager_info['InstanceId']
+        logger.info(f"cluster manager instance id: {cluster_manager_instance_id}")
+
+        ssm_client = boto3.client('ssm', region_name=cluster_region)
+        commands = f"""
+set -ex
+
+if ! [ -e /opt/slurm/{cluster_name} ]; then
+    sudo mkdir -p /opt/slurm/{cluster_name}
+fi
+if ! mountpoint /opt/slurm/{cluster_name} ; then
+    sudo mount head_node.{cluster_name}.pcluster:/opt/slurm /opt/slurm/{cluster_name} || true
+fi
+
+script="/opt/slurm/{cluster_name}/config/bin/create_users_groups_json_configure.sh"
+if ! [ -e $script ]; then
+    echo "$script doesn't exist"
+    exit 1
+fi
+
+sudo $script
+        """
+        response = ssm_client.send_command(
+            DocumentName = 'AWS-RunShellScript',
+            InstanceIds = [cluster_manager_instance_id],
+            Parameters = {'commands': [commands]},
+            Comment = f"Configure {environment_name} cluster manager for {cluster_name}"
+        )
+        logger.info(f"Sent SSM command {response['Command']['CommandId']}")
+
+    except Exception as e:
+        logger.exception(str(e))
+        raise

--- a/source/resources/lambdas/ConfigureSubmitters/ConfigureSubmitters.py
+++ b/source/resources/lambdas/ConfigureSubmitters/ConfigureSubmitters.py
@@ -1,0 +1,105 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+'''
+Call /opt/slurm/{{ClusterName}}/config/bin/on_head_node_updated.sh using ssm run command.
+'''
+import boto3
+import json
+import logging
+from os import environ as environ
+
+logger=logging.getLogger(__file__)
+logger_formatter = logging.Formatter('%(levelname)s: %(message)s')
+logger_streamHandler = logging.StreamHandler()
+logger_streamHandler.setFormatter(logger_formatter)
+logger.addHandler(logger_streamHandler)
+logger.setLevel(logging.INFO)
+logger.propagate = False
+
+def lambda_handler(event, context):
+    try:
+        logger.info(f"event:\n{json.dumps(event, indent=4)}")
+
+        cluster_name = environ['ClusterName']
+        cluster_region = environ['Region']
+        environment_name = environ['RESEnvironmentName']
+        logger.info(f"Configure RES({environment_name}) submitters for {cluster_name} in {cluster_region}")
+
+        ec2_client = boto3.client('ec2', region_name=cluster_region)
+        describe_instances_paginator = ec2_client.get_paginator('describe_instances')
+        describe_instances_iterator = describe_instances_paginator.paginate(
+            Filters = [
+                {'Name': 'tag:res:EnvironmentName', 'Values': [environment_name]},
+                {'Name': 'tag:res:NodeType', 'Values': ['virtual-desktop-dcv-host']}
+            ]
+        )
+        submitter_instance_ids = []
+        reservation_index = 0
+        for response in describe_instances_iterator:
+            for reservation_info in response['Reservations']:
+                logger.info(f"reservation[{reservation_index}]:")
+                reservation_index += 1
+                instance_index = 0
+                for instance_info in reservation_info['Instances']:
+                    logger.info(f"    instance[{instance_index}]:")
+                    instance_index += 1
+                    logger.info(f"        instance_id: {instance_info['InstanceId']}")
+                    if instance_info['State']['Name'] != 'running':
+                        logger.info(f"            Skipping because state = {instance_info['State']['Name']}")
+                        continue
+                    for tags in instance_info['Tags']:
+                        logger.info(f"            {tags}")
+                    submitter_instance_ids.append(instance_info['InstanceId'])
+        logger.info(f"submitter_instance_ids: {submitter_instance_ids}")
+        if not submitter_instance_ids:
+            logger.info("No running submitters.")
+            return
+
+        ssm_client = boto3.client('ssm', region_name=cluster_region)
+        commands = f"""
+set -ex
+
+if ! [ -e /opt/slurm/{cluster_name} ]; then
+    sudo mkdir -p /opt/slurm/{cluster_name}
+fi
+if ! mountpoint /opt/slurm/{cluster_name} ; then
+    sudo mount head_node.{cluster_name}.pcluster:/opt/slurm /opt/slurm/{cluster_name} || true
+fi
+
+script="/opt/slurm/{cluster_name}/config/bin/submitter_configure.sh"
+if ! [ -e $script ]; then
+    echo "$script doesn't exist"
+    exit 1
+fi
+
+sudo $script
+        """
+        # @todo Command is failing because the DCV instance doesn't have permissions to describe instances in the playbook
+        # I should be able to pass it in as a variable.
+        response = ssm_client.send_command(
+            DocumentName = 'AWS-RunShellScript',
+            InstanceIds = submitter_instance_ids,
+            Parameters = {'commands': [commands]},
+            Comment = f"Configure {environment_name} submitters for {cluster_name}"
+        )
+        logger.info(f"Sent SSM command {response['Command']['CommandId']}")
+
+    except Exception as e:
+        logger.exception(str(e))
+        raise

--- a/source/resources/lambdas/CreateHeadNodeARecord/CreateHeadNodeARecord.py
+++ b/source/resources/lambdas/CreateHeadNodeARecord/CreateHeadNodeARecord.py
@@ -1,0 +1,111 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+'''
+Create an A record for the ParallelCluster head node.
+
+This should be called by on_head_node_started.sh.
+'''
+import boto3
+import json
+import logging
+from os import environ as environ
+
+logger=logging.getLogger(__file__)
+logger_formatter = logging.Formatter('%(levelname)s: %(message)s')
+logger_streamHandler = logging.StreamHandler()
+logger_streamHandler.setFormatter(logger_formatter)
+logger.addHandler(logger_streamHandler)
+logger.setLevel(logging.INFO)
+logger.propagate = False
+
+def lambda_handler(event, context):
+    try:
+        logger.info(f"event:\n{json.dumps(event, indent=4)}")
+
+        cluster_name = environ['ClusterName']
+        cluster_region = environ['Region']
+        logger.info(f"Create head node A record for {cluster_name} in {cluster_region}")
+
+        route53_client = boto3.client('route53', region_name=cluster_region)
+
+        # Get the ParallelCluster hosted zone
+        hosted_zone_name = f"{cluster_name}.pcluster."
+        hosted_zone_id = None
+        list_hosted_zones_paginator = route53_client.get_paginator('list_hosted_zones')
+        for response in list_hosted_zones_paginator.paginate():
+            for hosted_zone_info in response['HostedZones']:
+                if hosted_zone_info['Name'] == hosted_zone_name:
+                    hosted_zone_id = hosted_zone_info['Id']
+                    logger.info(f"{hosted_zone_name} hosted zone id: {hosted_zone_id}")
+                    break
+            if hosted_zone_id:
+                break
+        if not hosted_zone_id:
+            raise ValueError(f"No private hosted zone named {hosted_zone_name} found.")
+
+        # Check to see if the A record already exists
+        # /hostedzone/Z007151912IBQH21Y4P5H
+        list_resource_record_sets_paginator = route53_client.get_paginator('list_resource_record_sets')
+        list_resource_record_sets_iterator = list_resource_record_sets_paginator.paginate(HostedZoneId=hosted_zone_id)
+        head_node_a_record_name = f"head_node.{hosted_zone_name}"
+        for response in list_resource_record_sets_iterator:
+            for resource_record_set_info in response['ResourceRecordSets']:
+                if resource_record_set_info['Type'] != 'A':
+                    continue
+                if resource_record_set_info['Name'] == head_node_a_record_name:
+                    logger.info(f"{head_node_a_record_name} A record already exists")
+                    return
+
+        logger.info(f"Creating {head_node_a_record_name} A record.")
+
+        ec2_client = boto3.client('ec2', region_name=cluster_region)
+        head_node_info = ec2_client.describe_instances(
+            Filters = [
+                {'Name': 'tag:parallelcluster:cluster-name', 'Values': [cluster_name]},
+                {'Name': 'tag:parallelcluster:node-type', 'Values': ['HeadNode']}
+            ]
+        )['Reservations'][0]['Instances'][0]
+        head_node_ip_address = head_node_info['PrivateIpAddress']
+        head_node_instance_id = head_node_info['InstanceId']
+        logger.info(f"head node instance id: {head_node_instance_id}")
+        logger.info(f"head node ip address: {head_node_ip_address}")
+
+        route53_client.change_resource_record_sets(
+            HostedZoneId = hosted_zone_id,
+            ChangeBatch = {
+                'Changes': [
+                    {
+                        'Action': 'CREATE',
+                        'ResourceRecordSet': {
+                            'Name': head_node_a_record_name,
+                            'Type': 'A',
+                            'ResourceRecords': [
+                                {'Value': str(head_node_ip_address)}
+                            ],
+                            'TTL': 300,
+                        }
+                    }
+                ]
+            }
+        )
+        logger.info(f"Successfully created {head_node_a_record_name} A record")
+
+    except Exception as e:
+        logger.exception(str(e))
+        raise

--- a/source/resources/lambdas/DeconfigureClusterManager/DeconfigureClusterManager.py
+++ b/source/resources/lambdas/DeconfigureClusterManager/DeconfigureClusterManager.py
@@ -1,0 +1,170 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+'''
+Update the head node when the config assets hash changes.
+'''
+import boto3
+import cfnresponse
+import json
+import logging
+from os import environ as environ
+import time
+
+logger=logging.getLogger(__file__)
+logger_formatter = logging.Formatter('%(levelname)s: %(message)s')
+logger_streamHandler = logging.StreamHandler()
+logger_streamHandler.setFormatter(logger_formatter)
+logger.addHandler(logger_streamHandler)
+logger.setLevel(logging.INFO)
+logger.propagate = False
+
+def lambda_handler(event, context):
+    try:
+        logger.info(f"event:\n{json.dumps(event, indent=4)}")
+        cluster_name = None
+        requestType = event['RequestType']
+        properties = event['ResourceProperties']
+        required_properties = [
+            ]
+        error_message = ""
+        for property in required_properties:
+            try:
+                value = properties[property]
+            except:
+                error_message += f"Missing {property} property. "
+        if error_message:
+            logger.info(error_message)
+            if requestType == 'Delete':
+                cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId=cluster_name)
+                return
+            else:
+                raise KeyError(error_message)
+
+        cluster_name = environ['ClusterName']
+        cluster_region = environ['Region']
+        environment_name = environ['RESEnvironmentName']
+        logger.info(f"{requestType} request for {cluster_name} in {cluster_region}")
+
+        if requestType != 'Delete':
+            logger.info(f"Nothing to do for {requestType}")
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId=cluster_name)
+            return
+
+        ec2_client = boto3.client('ec2', region_name=cluster_region)
+        cluster_manager_info = ec2_client.describe_instances(
+            Filters = [
+                {'Name': 'tag:res:EnvironmentName', 'Values': [environment_name]},
+                {'Name': 'tag:res:ModuleId', 'Values': ['cluster-manager']}
+            ]
+        )['Reservations'][0]['Instances'][0]
+        cluster_manager_instance_id = cluster_manager_info['InstanceId']
+        logger.info(f"cluster manager instance id: {cluster_manager_instance_id}")
+
+        ssm_client = boto3.client('ssm', region_name=cluster_region)
+        commands = f"""
+set -ex
+
+mount_dest=/opt/slurm/{cluster_name}
+
+# Make sure that the cluster is still mounted and mount is accessible.
+# If the cluster has already been deleted then the mount will be hung and we have to do manual cleanup.
+if mount | grep " $mount_dest "; then
+    echo "$mount_dest is mounted."
+    if ! timeout 1s ls $mount_dest; then
+        echo "Mount point ($mount_dest) is hung. Source may have already been deleted."
+        timeout 5s sudo umount -lf $mount_dest
+        timeout 1s rm -rf $mount_dest
+    fi
+fi
+
+script="$mount_dest/config/bin/create_users_groups_json_deconfigure.sh"
+if ! timeout 1s ls $script; then
+    echo "$script doesn't exist or isn't accessible."
+else
+    sudo $script
+fi
+
+# Do manual cleanup just in case something above failed.
+
+sudo grep -v " $mount_dest " /etc/fstab > /etc/fstab.new
+if diff -q /etc/fstab /etc/fstab.new; then
+    sudo rm -f /etc/fstab.new
+else
+    sudo cp /etc/fstab /etc/fstab.$(date '+%Y-%m-%d@%H:%M:%S~')
+    sudo mv -f /etc/fstab.new /etc/fstab
+fi
+
+if timeout 1s mountpoint $mount_dest; then
+    echo "$mount_dest is a mountpoint"
+    sudo umount -lf $mount_dest
+fi
+
+if timeout 1s ls $mount_dest; then
+    sudo rmdir $mount_dest
+fi
+        """
+        logger.info(f"Submitting SSM command")
+        response = ssm_client.send_command(
+            DocumentName = 'AWS-RunShellScript',
+            InstanceIds = [cluster_manager_instance_id],
+            Parameters = {'commands': [commands]},
+            Comment = f"Deconfigure {environment_name} cluster manager for {cluster_name}"
+        )
+        command_id = response['Command']['CommandId']
+        logger.info(f"Sent SSM command {command_id}")
+
+        # Wait for the command invocations to be made
+        time.sleep(5)
+        # Wait for the command to complete before returning so that the cluster resources aren't removed before the command completes.
+        num_errors = 0
+        MAX_WAIT_TIME = 13 * 60
+        wait_time = 0
+        instance_id = cluster_manager_instance_id
+        command_complete = False
+        while not command_complete:
+            response = ssm_client.get_command_invocation(
+                CommandId = command_id,
+                InstanceId = instance_id
+            )
+            command_status = response['Status']
+            if command_status in ['Success']:
+                logger.info(f"Command passed on {instance_id}")
+                break
+            elif command_status in ['Cancelled', 'TimedOut', 'Failed', 'Cancelling']:
+                logger.error(f"Command {command_status} on {instance_id}")
+                num_errors += 1
+                break
+            else:
+                logger.info(f"Command still running on {instance_id}")
+            if wait_time >= MAX_WAIT_TIME:
+                logger.error(f"Timed out waiting for command completion.")
+                num_errors += 1
+                break
+            time.sleep(10)
+            wait_time += 10
+        if num_errors:
+            cfnresponse.send(event, context, cfnresponse.FAILED, {'error': f"Denconfigure command failed."}, physicalResourceId=cluster_name)
+            return
+
+    except Exception as e:
+        logger.exception(str(e))
+        cfnresponse.send(event, context, cfnresponse.FAILED, {'error': str(e)}, physicalResourceId=cluster_name)
+        raise
+
+    cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId=cluster_name)

--- a/source/resources/lambdas/DeconfigureClusterManager/cfnresponse.py
+++ b/source/resources/lambdas/DeconfigureClusterManager/cfnresponse.py
@@ -1,0 +1,1 @@
+../cfnresponse.py

--- a/source/resources/lambdas/DeconfigureSubmitters/DeconfigureSubmitters.py
+++ b/source/resources/lambdas/DeconfigureSubmitters/DeconfigureSubmitters.py
@@ -1,0 +1,194 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+'''
+Update the head node when the config assets hash changes.
+'''
+import boto3
+import cfnresponse
+import json
+import logging
+from os import environ as environ
+import time
+
+logger=logging.getLogger(__file__)
+logger_formatter = logging.Formatter('%(levelname)s: %(message)s')
+logger_streamHandler = logging.StreamHandler()
+logger_streamHandler.setFormatter(logger_formatter)
+logger.addHandler(logger_streamHandler)
+logger.setLevel(logging.INFO)
+logger.propagate = False
+
+def lambda_handler(event, context):
+    try:
+        logger.info(f"event:\n{json.dumps(event, indent=4)}")
+        cluster_name = None
+        requestType = event['RequestType']
+        properties = event['ResourceProperties']
+        required_properties = [
+            ]
+        error_message = ""
+        for property in required_properties:
+            try:
+                value = properties[property]
+            except:
+                error_message += f"Missing {property} property. "
+        if error_message:
+            logger.info(error_message)
+            if requestType == 'Delete':
+                cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId=cluster_name)
+                return
+            else:
+                raise KeyError(error_message)
+
+        cluster_name = environ['ClusterName']
+        cluster_region = environ['Region']
+        environment_name = environ['RESEnvironmentName']
+        logger.info(f"{requestType} request for {cluster_name} in {cluster_region}")
+
+        if requestType != 'Delete':
+            logger.info(f"Nothing to do for {requestType}")
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId=cluster_name)
+            return
+
+        logger.info(f"Deconfigure RES({environment_name}) submitters for {cluster_name} in {cluster_region}")
+
+        ec2_client = boto3.client('ec2', region_name=cluster_region)
+        describe_instances_paginator = ec2_client.get_paginator('describe_instances')
+        describe_instances_iterator = describe_instances_paginator.paginate(
+            Filters = [
+                {'Name': 'tag:res:EnvironmentName', 'Values': [environment_name]},
+                {'Name': 'tag:res:NodeType', 'Values': ['virtual-desktop-dcv-host']}
+            ]
+        )
+        submitter_instance_ids = []
+        reservation_index = 0
+        for response in describe_instances_iterator:
+            for reservation_info in response['Reservations']:
+                logger.info(f"reservation[{reservation_index}]:")
+                reservation_index += 1
+                instance_index = 0
+                for instance_info in reservation_info['Instances']:
+                    logger.info(f"    instance[{instance_index}]:")
+                    instance_index += 1
+                    logger.info(f"        instance_id: {instance_info['InstanceId']}")
+                    if instance_info['State']['Name'] != 'running':
+                        logger.info(f"            Skipping because state = {instance_info['State']['Name']}")
+                        continue
+                    for tags in instance_info['Tags']:
+                        logger.info(f"            {tags}")
+                    submitter_instance_ids.append(instance_info['InstanceId'])
+        logger.info(f"submitter_instance_ids: {submitter_instance_ids}")
+        if not submitter_instance_ids:
+            logger.info("No running submitters.")
+            return
+
+        ssm_client = boto3.client('ssm', region_name=cluster_region)
+        commands = f"""
+set -ex
+
+mount_dest=/opt/slurm/{cluster_name}
+
+# Make sure that the cluster is still mounted and mount is accessible.
+# If the cluster has already been deleted then the mount will be hung and we have to do manual cleanup.
+if mount | grep " $mount_dest "; then
+    echo "$mount_dest is mounted."
+    if ! timeout 1s ls $mount_dest; then
+        echo "Mount point ($mount_dest) is hung. Source may have already been deleted."
+        timeout 5s sudo umount -lf $mount_dest
+        timeout 1s rm -rf $mount_dest
+    fi
+fi
+
+script="$mount_dest/config/bin/submitter_deconfigure.sh"
+if ! timeout 1s ls $script; then
+    echo "$script doesn't exist"
+else
+    sudo $script
+fi
+
+# Do manual cleanup just in case something above failed.
+
+sudo rm -f /etc/profile.d/slurm_{cluster_name}_modulefiles.sh
+
+sudo grep -v ' $mount_dest ' /etc/fstab > /etc/fstab.new
+if diff -q /etc/fstab /etc/fstab.new; then
+    sudo rm -f /etc/fstab.new
+else
+    sudo cp /etc/fstab /etc/fstab.$(date '+%Y-%m-%d@%H:%M:%S~')
+    sudo mv -f /etc/fstab.new /etc/fstab
+fi
+
+if timeout 1s mountpoint $mount_dest; then
+    echo "$mount_dest is a mountpoint"
+    sudo umount -lf $mount_dest
+fi
+
+if timeout 1s ls $mount_dest; then
+    sudo rmdir $mount_dest
+fi
+        """
+        response = ssm_client.send_command(
+            DocumentName = 'AWS-RunShellScript',
+            InstanceIds = submitter_instance_ids,
+            Parameters = {'commands': [commands]},
+            Comment = f"Deconfigure {environment_name} submitters for {cluster_name}"
+        )
+        command_id = response['Command']['CommandId']
+        logger.info(f"Sent SSM command {command_id}")
+
+        # Wait for the command invocations to be made
+        time.sleep(5)
+        # Wait for the command to complete before returning so that the cluster resources aren't removed before the command completes.
+        num_errors = 0
+        MAX_WAIT_TIME = 13 * 60
+        wait_time = 0
+        for instance_id in submitter_instance_ids:
+            command_complete = False
+            while not command_complete:
+                response = ssm_client.get_command_invocation(
+                    CommandId = command_id,
+                    InstanceId = instance_id
+                )
+                command_status = response['Status']
+                if command_status in ['Success']:
+                    logger.info(f"Command passed on {instance_id}")
+                    break
+                elif command_status in ['Cancelled', 'TimedOut', 'Failed', 'Cancelling']:
+                    logger.error(f"Command {command_status} on {instance_id}")
+                    num_errors += 1
+                    break
+                else:
+                    logger.info(f"Command still running on {instance_id}")
+                if wait_time >= MAX_WAIT_TIME:
+                    logger.error(f"Timed out waiting for command completion.")
+                    num_errors += 1
+                    break
+                break
+                time.sleep(10)
+            wait_time += 10
+        if num_errors:
+            cfnresponse.send(event, context, cfnresponse.FAILED, {'error': f"Denconfigure command failed."}, physicalResourceId=cluster_name)
+            return
+
+    except Exception as e:
+        logger.exception(str(e))
+        cfnresponse.send(event, context, cfnresponse.FAILED, {'error': str(e)}, physicalResourceId=cluster_name)
+        raise
+
+    cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId=cluster_name)

--- a/source/resources/lambdas/DeconfigureSubmitters/cfnresponse.py
+++ b/source/resources/lambdas/DeconfigureSubmitters/cfnresponse.py
@@ -1,0 +1,1 @@
+../cfnresponse.py

--- a/source/resources/lambdas/UpdateHeadNode/UpdateHeadNode.py
+++ b/source/resources/lambdas/UpdateHeadNode/UpdateHeadNode.py
@@ -1,0 +1,123 @@
+"""
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: MIT-0
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+'''
+Update the head node when the config assets hash changes.
+'''
+import boto3
+import cfnresponse
+import json
+import logging
+from os import environ as environ
+from textwrap import dedent
+
+logger=logging.getLogger(__file__)
+logger_formatter = logging.Formatter('%(levelname)s: %(message)s')
+logger_streamHandler = logging.StreamHandler()
+logger_streamHandler.setFormatter(logger_formatter)
+logger.addHandler(logger_streamHandler)
+logger.setLevel(logging.INFO)
+logger.propagate = False
+
+def lambda_handler(event, context):
+    try:
+        logger.info(f"event:\n{json.dumps(event, indent=4)}")
+        cluster_name = None
+        requestType = event['RequestType']
+        properties = event['ResourceProperties']
+        required_properties = [
+            'ParallelClusterConfigHash'
+            ]
+        error_message = ""
+        for property in required_properties:
+            try:
+                value = properties[property]
+            except:
+                error_message += f"Missing {property} property. "
+        if error_message:
+            logger.info(error_message)
+            if requestType == 'Delete':
+                cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId=cluster_name)
+                return
+            else:
+                raise KeyError(error_message)
+
+        cluster_name = environ['ClusterName']
+        cluster_region = environ['Region']
+        logger.info(f"{requestType} request for {cluster_name} in {cluster_region}")
+        logger.info(f"ParallelClusterConfigHash={properties['ParallelClusterConfigHash']}")
+
+        if requestType == 'Delete':
+            logger.info(f"Nothing to do for Delete")
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId=cluster_name)
+            return
+        if requestType == 'Create':
+            logger.info(f"Nothing to do for Create")
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId=cluster_name)
+            return
+
+        ec2_client = boto3.client('ec2', region_name=cluster_region)
+        reservations_info = ec2_client.describe_instances(
+            Filters = [
+                {'Name': 'tag:parallelcluster:cluster-name', 'Values': [cluster_name]},
+                {'Name': 'tag:parallelcluster:node-type', 'Values': ['HeadNode']}
+            ]
+        )['Reservations']
+        # If the cluster hasn't deployed yet or didn't successfully deploy initially, then the head node might not exist.
+        # This shouldn't cause the custom resource to fail.
+        if not reservations_info:
+            logger.info(f"No head node instance found.")
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId=cluster_name)
+            return
+        instances_info = reservations_info[0]['Instances']
+        if not instances_info:
+            logger.info(f"No head node instance found.")
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId=cluster_name)
+            return
+        head_node_info = instances_info[0]
+        head_node_ip_address = head_node_info['PrivateIpAddress']
+        head_node_instance_id = head_node_info['InstanceId']
+        logger.info(f"head node instance id: {head_node_instance_id}")
+        logger.info(f"head node ip address: {head_node_ip_address}")
+
+        ssm_client = boto3.client('ssm', region_name=cluster_region)
+        commands = f"""
+set -ex
+
+script="/opt/slurm/config/bin/on_head_node_updated.sh"
+if ! [ -e $script ]; then
+    echo "$script doesn't exist"
+    exit 0
+fi
+
+sudo $script
+        """
+        response = ssm_client.send_command(
+            DocumentName = 'AWS-RunShellScript',
+            InstanceIds = [head_node_instance_id],
+            Parameters = {'commands': [commands]},
+            Comment = f"''Update head node of {cluster_name}({head_node_instance_id})"
+        )
+        logger.info(f"Sent SSM command {response['Command']['CommandId']}")
+
+    except Exception as e:
+        logger.exception(str(e))
+        cfnresponse.send(event, context, cfnresponse.FAILED, {'error': str(e)}, physicalResourceId=cluster_name)
+        raise
+
+    cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId=cluster_name)

--- a/source/resources/lambdas/UpdateHeadNode/cfnresponse.py
+++ b/source/resources/lambdas/UpdateHeadNode/cfnresponse.py
@@ -1,0 +1,1 @@
+../cfnresponse.py

--- a/source/resources/parallel-cluster/config/bin/create_or_update_users_groups_json.sh
+++ b/source/resources/parallel-cluster/config/bin/create_or_update_users_groups_json.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -xe
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
 # This script creates the json file with user and group information.
 
 full_script=$(realpath $0)

--- a/source/resources/parallel-cluster/config/bin/create_users_groups_json_configure.sh
+++ b/source/resources/parallel-cluster/config/bin/create_users_groups_json_configure.sh
@@ -1,4 +1,7 @@
 #!/bin/bash -xe
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
 # This script creates the json file with user and group information.
 # It also creates a crontab entry to update the json file every hour.
 

--- a/source/resources/parallel-cluster/config/bin/install-ansible.sh
+++ b/source/resources/parallel-cluster/config/bin/install-ansible.sh
@@ -1,4 +1,6 @@
 #!/bin/bash -x
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
 
 script=$0
 

--- a/source/resources/parallel-cluster/config/bin/on_compute_node_configured.sh
+++ b/source/resources/parallel-cluster/config/bin/on_compute_node_configured.sh
@@ -1,27 +1,63 @@
 #!/bin/bash -x
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
 
 set -x
 
-exec 1> >(logger -s -t on_compute_node_configured.sh) 2>&1
+script_name=on_compute_node_configured.sh
 
-full_script=$(realpath $0)
-script_dir=$(dirname $full_script)
-base_script=$(basename $full_script)
+exec 1> >(logger -s -t ${script_name}) 2>&1
 
-date
-echo "Started on_compute_node_configured.sh: $full_script"
+echo "$(date): Started ${script_name}"
+
+# Jinja2 template variables
+assets_bucket={{assets_bucket}}
+assets_base_key={{assets_base_key}}
+export AWS_DEFAULT_REGION={{Region}}
+ErrorSnsTopicArn={{ErrorSnsTopicArn}}
+HomeMountSrc={{HomeMountSrc}}
+playbooks_s3_url={{playbooks_s3_url}}
+
+# Notify user of errors
+function on_exit {
+    rc=$?
+    set +e
+    if [[ $rc -ne 0 ]] && [[ ":$ErrorSnsTopicArn" != ":" ]]; then
+        message_file=$(mktemp)
+        echo "See log files for more info:
+    grep ${script_name} /var/log/messages | less" > $message_file
+        aws sns publish --topic-arn $ErrorSnsTopicArn --subject "${ClusterName} ${script_name} failed" --message file://$message_file
+        rm $message_file
+    fi
+}
+trap on_exit EXIT
 
 config_dir=/opt/slurm/config
 config_bin_dir=$config_dir/bin
 
-assets_bucket={{assets_bucket}}
-assets_base_key={{assets_base_key}}
+if ! [ -z $HomeMountSrc ]; then
+    umount /home
+    mount $HomeMountSrc /home
+fi
 
-dest_script="$config_bin_dir/on_compute_node_configured.sh"
-if [ $full_script != $dest_script ]; then
-    echo "cp $full_script $dest_script"
-    cp $full_script $dest_script
-    chmod 0700 $dest_script
+if ! diff -q $config_dir/munge.key /etc/munge/munge.key; then
+    echo "Updating /etc/munge/munge.key"
+    /usr/bin/cp /etc/munge/munge.key /etc/munge/munge.key.back$(date '+%Y-%m-%dT%H:%M:%S')
+    /usr/bin/cp $config_dir/munge.key /etc/munge/munge.key
+    systemctl restart munge
+    systemctl restart slurmd
+fi
+
+# Make sure we're running the latest version
+dest_script="$config_bin_dir/${script_name}"
+mkdir -p $config_bin_dir
+aws s3 cp s3://$assets_bucket/$assets_base_key/config/bin/${script_name} $dest_script.new
+chmod 0700 $dest_script.new
+if ! [ -e $dest_script ] || ! diff -q $dest_script $dest_script.new; then
+    mv -f $dest_script.new $dest_script
+    exec $dest_script
+else
+    rm $dest_script.new
 fi
 
 export PATH=/usr/sbin:$PATH
@@ -44,7 +80,6 @@ $config_bin_dir/create_users_groups.py -i $config_dir/users_groups.json
 #     -e @$ANSIBLE_PATH/ansible_compute_node_vars.yml &
 # popd
 
-date
-echo "Finished on_compute_node_configured.sh: $full_script"
+echo "$(date): Finished ${script_name}"
 
 exit 0

--- a/source/resources/parallel-cluster/config/bin/on_compute_node_start.sh
+++ b/source/resources/parallel-cluster/config/bin/on_compute_node_start.sh
@@ -1,21 +1,35 @@
 #!/bin/bash -x
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
 
 set -x
+set -e
 
-exec 1> >(logger -s -t on_compute_node_start.sh) 2>&1
+script_name=on_compute_node_start.sh
 
-full_script=$(realpath $0)
-script_dir=$(dirname $full_script)
-base_script=$(basename $full_script)
+exec 1> >(logger -s -t ${script_name}) 2>&1
 
-date
-echo "Started on_compute_node_start.sh: $full_script"
+echo "$(date): Started ${script_name}"
+
+# Jinja2 template variables
+ErrorSnsTopicArn={{ErrorSnsTopicArn}}
+
+# Notify user of errors
+function on_exit {
+    rc=$?
+    set +e
+    if [[ $rc -ne 0 ]] && [[ ":$ErrorSnsTopicArn" != ":" ]]; then
+        message_file=$(mktemp)
+        echo "See log files for more info:
+    grep ${script_name} /var/log/messages | less" > $message_file
+        aws sns publish --topic-arn $ErrorSnsTopicArn --subject "${ClusterName} ${script_name} failed" --message file://$message_file
+        rm $message_file
+    fi
+}
+trap on_exit EXIT
 
 # /opt/slurm isn't mounted yet.
 
-export PATH=/usr/sbin:$PATH
-
-date
-echo "Finished on_compute_node_start.sh: $full_script"
+echo "$(date): Finished ${script_name}"
 
 exit 0

--- a/source/resources/parallel-cluster/config/bin/on_head_node_configured.sh
+++ b/source/resources/parallel-cluster/config/bin/on_head_node_configured.sh
@@ -1,31 +1,80 @@
 #!/bin/bash -x
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
 
 set -x
+set -e
 
-exec 1> >(logger -s -t on_head_node_configured.sh) 2>&1
+script_name=on_head_node_configured.sh
 
-full_script=$(realpath $0)
-script_dir=$(dirname $full_script)
-base_script=$(basename $full_script)
+exec 1> >(logger -s -t ${script_name}) 2>&1
 
-date
-echo "Started on_head_node_configured.sh: $full_script"
+echo "$(date): Started ${script_name}"
+
+# Jinja2 template variables
+assets_bucket={{assets_bucket}}
+assets_base_key={{assets_base_key}}
+export AWS_DEFAULT_REGION={{Region}}
+MungeKeySecretId={{MungeKeySecretId}}
+playbooks_s3_url={{playbooks_s3_url}}
+
+# Notify user of errors
+function on_exit {
+    rc=$?
+    set +e
+    if [[ $rc -ne 0 ]] && [[ ":$ErrorSnsTopicArn" != ":" ]]; then
+        message_file=$(mktemp)
+        echo "See log files for more info:
+    grep ${script_name} /var/log/messages | less" > $message_file
+        aws sns publish --topic-arn $ErrorSnsTopicArn --subject "${ClusterName} ${script_name} failed" --message file://$message_file
+        rm $message_file
+    fi
+}
+trap on_exit EXIT
 
 config_dir=/opt/slurm/config
 config_bin_dir=$config_dir/bin
 ANSIBLE_PATH=$config_dir/ansible
 PLAYBOOKS_PATH=$ANSIBLE_PATH/playbooks
 
-dest_script="$config_bin_dir/on_head_node_configured.sh"
-if [ $full_script != $dest_script ]; then
-    echo "cp $full_script $dest_script"
-    cp $full_script $dest_script
-    chmod 0700 $dest_script
+# Make sure we're running the latest version
+dest_script="$config_bin_dir/${script_name}"
+mkdir -p $config_bin_dir
+aws s3 cp s3://$assets_bucket/$assets_base_key/config/bin/${script_name} $dest_script.new
+chmod 0700 $dest_script.new
+if ! [ -e $dest_script ] || ! diff -q $dest_script $dest_script.new; then
+    mv -f $dest_script.new $dest_script
+    exec $dest_script
+else
+    rm $dest_script.new
 fi
 
 export PATH=/usr/sbin:$PATH
 
+# Rerun on_head_node_start.sh to download latest versions of all config files and scripts
 $config_bin_dir/on_head_node_start.sh
+
+if ! [ -z $MungeKeySecretId ]; then
+    echo "Download munge key from $MungeKeySecretId"
+    munge_key_b64=$(aws secretsmanager get-secret-value --secret-id $MungeKeySecretId --query 'SecretString' --output text)
+    echo "$munge_key_b64" | base64 -d -w 0 > /etc/munge/munge.key.new
+    echo "" >> /etc/munge/munge.key.new
+    chown munge /etc/munge/munge.key.new
+    chmod 0600 /etc/munge/munge.key.new
+    if diff -q /etc/munge/munge.key /etc/munge/munge.key.new; then
+        echo "Munge key is correct"
+        rm -f /etc/munge/munge.key.new
+    else
+        echo "Update munge key from $MungeKeySecretId"
+        cp /etc/munge/munge.key /etc/munge/munge.key.back$(date '+%Y-%m-%dT%H:%M:%S')
+        mv -f /etc/munge/munge.key.new /etc/munge/munge.key
+        echo "Restart services"
+        systemctl restart munge
+        systemctl restart slurmdbd
+        systemctl restart slurmctld
+    fi
+fi
+/usr/bin/cp -f /etc/munge/munge.key $config_dir/munge.key
 
 pushd $PLAYBOOKS_PATH
 ansible-playbook $PLAYBOOKS_PATH/ParallelClusterHeadNode.yml \
@@ -33,7 +82,15 @@ ansible-playbook $PLAYBOOKS_PATH/ParallelClusterHeadNode.yml \
     -e @$ANSIBLE_PATH/ansible_head_node_vars.yml
 popd
 
-date
-echo "Finished on_head_node_configured.sh: $full_script"
+# Notify SNS topic that trigger configuration of cluster manager and submitters
+ConfigureClusterManagerSnsTopicArnParameter={{ConfigureClusterManagerSnsTopicArnParameter}}
+ConfigureClusterManagerSnsTopicArn=$(aws ssm get-parameter --name $ConfigureClusterManagerSnsTopicArnParameter --query 'Parameter.Value' --output text)
+aws sns publish --topic-arn $ConfigureClusterManagerSnsTopicArn --message '{{ClusterName}} configured'
+
+ConfigureSubmittersSnsTopicArnParameter={{ConfigureSubmittersSnsTopicArnParameter}}
+ConfigureSubmittersSnsTopicArn=$(aws ssm get-parameter --name $ConfigureSubmittersSnsTopicArnParameter --query 'Parameter.Value' --output text)
+aws sns publish --topic-arn $ConfigureSubmittersSnsTopicArn --message '{{ClusterName}} configured'
+
+echo "$(date): Finished ${script_name}"
 
 exit 0

--- a/source/resources/parallel-cluster/config/bin/on_head_node_updated.sh
+++ b/source/resources/parallel-cluster/config/bin/on_head_node_updated.sh
@@ -1,31 +1,54 @@
 #!/bin/bash -x
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
 
 set -x
+set -e
 
-exec 1> >(logger -s -t on_head_node_updated.sh) 2>&1
+script_name=on_head_node_updated.sh
 
-full_script=$(realpath $0)
-script_dir=$(dirname $full_script)
-base_script=$(basename $full_script)
+exec 1> >(logger -s -t ${script_name}) 2>&1
 
-date
-echo "Started on_head_node_updated.sh: $full_script"
+echo "$(date): Started ${script_name}"
+
+# Jinja2 template variables
+assets_bucket={{assets_bucket}}
+assets_base_key={{assets_base_key}}
+ErrorSnsTopicArn={{ErrorSnsTopicArn}}
+
+# Notify user of errors
+function on_exit {
+    rc=$?
+    set +e
+    if [[ $rc -ne 0 ]] && [[ ":$ErrorSnsTopicArn" != ":" ]]; then
+        message_file=$(mktemp)
+        echo "See log files for more info:
+    grep ${script_name} /var/log/messages | less" > $message_file
+        aws sns publish --topic-arn $ErrorSnsTopicArn --subject "${ClusterName} ${script_name} failed" --message file://$message_file
+        rm $message_file
+    fi
+}
+trap on_exit EXIT
 
 config_dir=/opt/slurm/config
 config_bin_dir=$config_dir/bin
 
-dest_script="$config_bin_dir/on_head_node_updated.sh"
-if [ $full_script != $dest_script ]; then
-    echo "cp $full_script $dest_script"
-    cp $full_script $dest_script
-    chmod 0700 $dest_script
+# Make sure we're running the latest version
+dest_script="$config_bin_dir/${script_name}"
+mkdir -p $config_bin_dir
+aws s3 cp s3://$assets_bucket/$assets_base_key/config/bin/${script_name} $dest_script.new
+chmod 0700 $dest_script.new
+if ! [ -e $dest_script ] || ! diff -q $dest_script $dest_script.new; then
+    mv -f $dest_script.new $dest_script
+    exec $dest_script
+else
+    rm $dest_script.new
 fi
 
 export PATH=/usr/sbin:$PATH
 
 $config_bin_dir/on_head_node_configured.sh
 
-date
-echo "Finished on_head_node_updated.sh: $full_script"
+echo "$(date): Finished ${script_name}"
 
 exit 0

--- a/source/resources/parallel-cluster/config/bin/submitter_configure.sh
+++ b/source/resources/parallel-cluster/config/bin/submitter_configure.sh
@@ -1,17 +1,36 @@
 #!/bin/bash -xe
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
 
 full_script=$(realpath $0)
 script_dir=$(dirname $full_script)
-base_script=$(basename $full_script)
+script_name=$(basename $full_script)
 
-date
-echo "Started submitter_configure.sh: $full_script"
+echo "$(date): Started ${script_name}"
 
-config_dir={{SubmitterSlurmConfigDir}}
-config_bin_dir=$config_dir/bin
-
+# Jinja2 template variables
 assets_bucket={{assets_bucket}}
 assets_base_key={{assets_base_key}}
+export AWS_DEFAULT_REGION={{Region}}
+ClusterName={{ClusterName}}
+config_dir={{SubmitterSlurmConfigDir}}
+ErrorSnsTopicArn={{ErrorSnsTopicArn}}
+
+# Notify user of errors
+function on_exit {
+    rc=$?
+    set +e
+    if [[ $rc -ne 0 ]] && [[ ":$ErrorSnsTopicArn" != ":" ]]; then
+        message_file=$(mktemp)
+        echo "See log files for more info:
+    grep ${script_name} /var/log/messages | less" > $message_file
+        aws sns publish --topic-arn $ErrorSnsTopicArn --subject "${ClusterName} ${script_name} failed" --message file://$message_file
+        rm $message_file
+    fi
+}
+trap on_exit EXIT
+
+config_bin_dir=$config_dir/bin
 
 # Configure using ansible
 if ! yum list installed ansible &> /dev/null; then
@@ -27,7 +46,26 @@ ansible-playbook $PLAYBOOKS_PATH/ParallelClusterSubmitterConfigure.yml \
     -e @$ANSIBLE_PATH/ansible_submitter_vars.yml
 popd
 
-date
-echo "Finished submitter_configure.sh: $full_script"
+modulefile_profile=/etc/profile.d/slurm_${ClusterName}_modulefiles.sh
+if ! [ -e $modulefile_profile ]; then
+    echo "error: $modulefile_profile doesn't exist"
+    exit 1
+fi
+modulefile=$(cat $modulefile_profile | grep 'module use' | cut -d ' ' -f 3)
+if [ -z $modulefile ]; then
+    echo "error: Couldn't get modulefile path from $modulefile_profile:"
+    cat $modulefile_profile
+    cat $modulefile_profile | grep 'module use'
+    exit1
+fi
+if ! [ -e $modulefile ]; then
+    pushd $PLAYBOOKS_PATH
+    ansible-playbook $PLAYBOOKS_PATH/ParallelClusterSubmitterInstallSlurm.yml \
+        -i inventories/local.yml \
+        -e @$ANSIBLE_PATH/ansible_submitter_vars.yml
+    popd
+fi
+
+echo "$(date): Finished ${script_name}"
 
 exit 0

--- a/source/resources/parallel-cluster/config/bin/submitter_deconfigure.sh
+++ b/source/resources/parallel-cluster/config/bin/submitter_deconfigure.sh
@@ -1,4 +1,6 @@
 #!/bin/bash -xe
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
 
 full_script=$(realpath $0)
 script_dir=$(dirname $full_script)
@@ -7,14 +9,20 @@ base_script=$(basename $full_script)
 date
 echo "Started submitter_deconfigure.sh: $full_script"
 
+ErrorSnsTopicArn={{ErrorSnsTopicArn}}
+
 config_dir={{SubmitterSlurmConfigDir}}
 config_bin_dir=$config_dir/bin
 
 temp_config_dir=/tmp/{{ClusterName}}_config
-rm -rf $temp_config_dir
-cp -r $config_dir $temp_config_dir
+temp_config_bin_dir=$temp_config_dir/bin
+if [[ $script_dir != $temp_config_bin_dir ]]; then
+    rm -rf $temp_config_dir
+    cp -r $config_dir $temp_config_dir
+    exec $temp_config_dir/bin/$base_script
+fi
 
-# Configure using ansible
+# Install ansible
 if ! yum list installed ansible &> /dev/null; then
     yum install -y ansible || amazon-linux-extras install -y ansible2
 fi

--- a/source/resources/playbooks/ParallelClusterSubmitterInstallSlurm.yml
+++ b/source/resources/playbooks/ParallelClusterSubmitterInstallSlurm.yml
@@ -1,0 +1,7 @@
+---
+- name: Compile slurm for ParallelCluster Submitter
+  hosts: ParallelClusterSubmitter
+  become_user: root
+  become: yes
+  roles:
+    - install_slurm

--- a/source/resources/playbooks/roles/ParallelClusterCreateUsersGroupsJsonConfigure/README.md
+++ b/source/resources/playbooks/roles/ParallelClusterCreateUsersGroupsJsonConfigure/README.md
@@ -4,8 +4,14 @@ ParallelClusterCreateUsersGroupsJsonConfigure
 Configure the server that is periodically updating the users_groups.json file.
 Creates the file and a cron job that refreshes it hourly.
 
+* Mounts the cluster's /opt/slurm export at /opt/slurm/{{ClusterName}}
+* Updates the /etc/fstab so that the mount works after a reboot.
+* Creates a crontab to refresh /opt/slurm/{{ClusterName}}/config/users_groups.json is refreshed hourly.
+
 Requirements
 ------------
 
 This is meant to be run on a server that is joined to your domain so that it
 has access to info about all of the users and groups.
+For SOCA, this is the scheduler instance.
+For RES, this is the {{EnvironmentName}}-cluster-manager instance.

--- a/source/resources/playbooks/roles/ParallelClusterCreateUsersGroupsJsonConfigure/tasks/main.yml
+++ b/source/resources/playbooks/roles/ParallelClusterCreateUsersGroupsJsonConfigure/tasks/main.yml
@@ -1,4 +1,20 @@
 ---
+# Tasks for ParallelClusterCreateUsersGroupsJsonConfigure
+
+- name: Show vars used in this playbook
+  debug:
+    msg: |
+      ClusterName:                {{ClusterName}}
+      Region:                     {{Region}}
+      SlurmConfigDir:             {{SlurmConfigDir}}
+
+- name: Add /opt/slurm/{{ClusterName}} to /etc/fstab
+  mount:
+    path: /opt/slurm/{{ClusterName}}
+    src:  "head_node.{{ClusterName}}.pcluster:/opt/slurm"
+    fstype: nfs
+    backup: true
+    state: present # Should already be mounted
 
 - name: Create {{SlurmConfigDir}}/users_groups.json
   shell: |
@@ -8,7 +24,7 @@
 
 - name: Create cron to refresh {{SlurmConfigDir}}/users_groups.json every hour
   template:
-    dest: /etc/cron.d/slurm_update_users_groups_json
+    dest: /etc/cron.d/slurm_{{ClusterName}}_update_users_groups_json
     src:   etc/cron.d/slurm_update_users_groups_json
     owner: root
     group: root

--- a/source/resources/playbooks/roles/ParallelClusterCreateUsersGroupsJsonDeconfigure/README.md
+++ b/source/resources/playbooks/roles/ParallelClusterCreateUsersGroupsJsonDeconfigure/README.md
@@ -4,6 +4,10 @@ ParallelClusterCreateUsersGroupsJsonDeconfigure
 Deconfigure the server that is periodically updating the users_groups.json file.
 Just removes the crontab entry on the server.
 
+* Copies ansible playbooks to /tmp because the cluster's mount is removed by the playbook.
+* Remove crontab that refreshes /opt/slurm/{{ClusterName}}/config/users_groups.json.
+* Remove /opt/slurm/{{ClusterName}} from /etc/fstab and unmount it.
+
 Requirements
 ------------
 

--- a/source/resources/playbooks/roles/ParallelClusterCreateUsersGroupsJsonDeconfigure/tasks/main.yml
+++ b/source/resources/playbooks/roles/ParallelClusterCreateUsersGroupsJsonDeconfigure/tasks/main.yml
@@ -1,6 +1,50 @@
 ---
+# Tasks for ParallelClusterCreateUsersGroupsJsonDeconfigure
+
+- name: Show vars used in this playbook
+  debug:
+    msg: |
+      ClusterName:                {{ClusterName}}
 
 - name: Delete cron to refresh {{SlurmConfigDir}}/users_groups.json every hour
   file:
-    dest: /etc/cron.d/slurm_update_users_groups_json
+    dest: /etc/cron.d/slurm_{{ClusterName}}_update_users_groups_json
+    state: absent
+
+- name: Unmount /opt/slurm/{{ClusterName}}
+  shell: |
+    set -ex
+
+    # Handle case where cluster was already deleted so the mountpoint is hung
+    if ! timeout 1s /opt/slurm/{{ClusterName}}; then
+        echo "Mount point is hung. Source has already been deleted."
+        umount -lf /opt/slurm/{{ClusterName}}
+    fi
+    if ! mountpoint /opt/slurm/{{ClusterName}}; then
+        echo "/opt/slurm/{{ClusterName}} already unmounted."
+        exit 0
+    fi
+    umount -lf /opt/slurm/{{ClusterName}} || lsof /opt/slurm/{{ClusterName}}
+  register: umount_results
+
+- name: Show umount results
+  debug:
+    msg: |
+      umount_results: {{umount_results}}
+
+- name: Remove /opt/slurm/{{ClusterName}} from /etc/fstab and ignore errors
+  mount:
+    path: /opt/slurm/{{ClusterName}}
+    backup: true
+    fstype: nfs
+    state: absent
+  # For some reason umount is failing with device busy even though running out of /tmp.
+  # Retry it again without ignoring errors.
+  ignore_errors: true
+
+- name: Remove /opt/slurm/{{ClusterName}} from /etc/fstab
+  mount:
+    path: /opt/slurm/{{ClusterName}}
+    backup: true
+    fstype: nfs
     state: absent

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/config-licenses.yml
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/config-licenses.yml
@@ -14,13 +14,24 @@
       server='{% if 'Server' in Licenses[lic] %}{{Licenses[lic].Server}}{% if 'Port' in Licenses[lic] %}@{{Licenses[lic].Port}}{% endif %}{% else %}slurmdb{% endif %}'
       count='{{Licenses[lic].Count}}'
       licenses["$license@$server"]="$count"
-      if ! {{SlurmBinDir}}/sacctmgr -i add resource type=License name=$license server=$server{% if 'ServerType' in Licenses[lic] %} servertype={{Licenses[lic].ServerType}}{% endif %} count={{Licenses[lic].Count}} cluster={{ClusterName}} percentallowed=100; then
-          # Exit 1: Nothing new added.
-          {{SlurmBinDir}}/sacctmgr -i modify resource name=$license server=$server set count={{Licenses[lic].Count}}
+      # Check to see if license has already been created
+      slurm_license=$({{SlurmBinDir}}/sacctmgr -i show resource $license --parsable2 --noheader)
+      if [ -z $slurm_license ]; then
+          echo "$license license not in slurmdbd so add it"
+          {{SlurmBinDir}}/sacctmgr -i add resource type=License name=$license server=$server{% if 'ServerType' in Licenses[lic] %} servertype={{Licenses[lic].ServerType}}{% endif %} count={{Licenses[lic].Count}} cluster={{ClusterName}} percentallowed=100
+      else
+          echo "$license already in slurmdbd so check count and percent allowed."
+          slurmdb_count=$({{SlurmBinDir}}/sacctmgr -i show resource $license --parsable2 --noheader | cut -d '|' -f 4)
+          echo "slurmdb count=$slurmdb_count"
+          if [[ $count != $slurmdb_count ]]; then
+              echo "Update $license count from $slurmdb_count to $count"
+              {{SlurmBinDir}}/sacctmgr -i modify resource name=$license server=$server set count=$count
+          fi
 
-          # This is required or else license count will stay at 0
-          {{SlurmBinDir}}/sacctmgr -i modify resource name=$license server=$server cluster={{ClusterName}} set percentallowed=100
-
+          slurmdb_percent_allowed=$({{SlurmBinDir}}/sacctmgr -i show resource $license --parsable2 --noheader | cut -d '|' -f 6)
+          if [[ "100" != $slurmdb_percent_allowed ]]; then
+              {{SlurmBinDir}}/sacctmgr -i modify resource name=$license server=$server cluster={{ClusterName}} set percentallowed=100
+          fi
       fi
       {% endfor -%}
 
@@ -36,3 +47,4 @@
       done
 
   register: remote_slurm_licenses_conf_result
+#   ignore_errors: true

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/config-slurmrestd.yml
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/config-slurmrestd.yml
@@ -31,7 +31,7 @@
 
       source /opt/parallelcluster/pyenv/versions/{{ParallelClusterPythonVersion}}/envs/cookbook_virtualenv/bin/activate
 
-      cd /etc/chef/local-mode-cache/cache/slurm-slurm-{{SlurmVersion}}
+      cd /etc/chef/local-mode-cache/cache/slurm-slurm-{{PCSlurmVersion}}
       ./configure --prefix /opt/slurm --with-pmix=/opt/pmix --with-slurmrestd --enable-slurmrestd &> configure.log
       CORES=$(grep processor /proc/cpuinfo | wc -l)
       make -j $CORES         &> make_all.log

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/config-submitter-access.yml
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/config-submitter-access.yml
@@ -1,5 +1,9 @@
 ---
 
+- name: Set variables used by the role
+  set_fact:
+    SlurmOSDir: /opt/slurm/{{ClusterName}}
+
 - name: Show vars used in this playbook
   debug:
     msg: |
@@ -11,6 +15,7 @@
       ParallelClusterVersion:     {{ParallelClusterVersion}}
       PCModulefilesBaseDir:       {{PCModulefilesBaseDir}}
       SlurmConfigDir:             {{SlurmConfigDir}}
+      SlurmOSDir:                 {{SlurmOSDir}}
 
 - name: Create /opt/slurm/{{ClusterName}} symbolic link
   # All head nodes are originally configured to use /opt/slurm

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/templates/opt/slurm/modules/modulefiles/slurm/.template
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/templates/opt/slurm/modules/modulefiles/slurm/.template
@@ -20,12 +20,12 @@ proc ModulesHelp { } {
 
 module-whatis "loads the env for $toolname version $version"
 
-prepend-path LD_LIBRARY_PATH {{SubmitterSlurmBaseDir}}/lib/slurm
+prepend-path LD_LIBRARY_PATH {{SlurmOSDir}}/lib/slurm
 
 # This overrides the "search" line in /etc/resolv.conf so that the pcluster route53 zone is used to resolve compute node host names.
 setenv LOCALDOMAIN "ec2.internal {{ClusterName}}.pcluster"
 
-prepend-path PATH {{SubmitterSlurmBaseDir}}/bin
+prepend-path PATH {{SlurmOSDir}}/bin
 
 setenv SLURM_CONF {{SubmitterSlurmBaseDir}}/etc/slurm.conf
 

--- a/source/resources/playbooks/roles/ParallelClusterSubmitterConfigure/README.md
+++ b/source/resources/playbooks/roles/ParallelClusterSubmitterConfigure/README.md
@@ -1,38 +1,7 @@
-Role Name
+ParallelClusterSubmitterConfigure
 =========
 
-A brief description of the role goes here.
+Configure a Submitter instance as a Slurm login node that can submit commands to a ParallelCluster cluster.
 
 Requirements
 ------------
-
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
-
-Role Variables
---------------
-
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
-
-Dependencies
-------------
-
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
-
-Example Playbook
-----------------
-
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
-
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
-
-License
--------
-
-BSD
-
-Author Information
-------------------
-
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/source/resources/playbooks/roles/ParallelClusterSubmitterConfigure/tasks/main.yml
+++ b/source/resources/playbooks/roles/ParallelClusterSubmitterConfigure/tasks/main.yml
@@ -8,26 +8,10 @@
       Region:                     {{Region}}
       SlurmBaseDir:               {{SlurmBaseDir}}
 
-- name: Get ip address of {{ClusterName}} head node
-  shell:
-    cmd: |
-      set -e
-
-      head_ip_address=$(aws ec2 describe-instances --region {{Region}} --filters 'Name=tag:parallelcluster:cluster-name,Values={{ClusterName}}' 'Name=tag:parallelcluster:node-type,Values=HeadNode' --query 'Reservations[0].Instances[0].PrivateIpAddress' --output text)
-      echo $head_ip_address
-  register: head_node_ip_address_results
-
-- name: Show ip address results
-  debug:
-    msg: |
-      head_node_ip_address_results: {{head_node_ip_address_results}}
-      head_node_ip_address_results.stdout_lines[0]: {{head_node_ip_address_results.stdout_lines[0]}}
-      head_node_ip_address_results.stdout:          {{head_node_ip_address_results.stdout}}
-
 - name: Add /opt/slurm/{{ClusterName}} to /etc/fstab
   mount:
     path: /opt/slurm/{{ClusterName}}
-    src: "{{head_node_ip_address_results.stdout_lines[0]}}:/opt/slurm"
+    src: "head_node.{{ClusterName}}.pcluster:/opt/slurm"
     fstype: nfs
     backup: true
     state: present # Should already be mounted

--- a/source/resources/playbooks/roles/ParallelClusterSubmitterDeconfigure/tasks/main.yml
+++ b/source/resources/playbooks/roles/ParallelClusterSubmitterDeconfigure/tasks/main.yml
@@ -10,6 +10,27 @@
     dest: /etc/profile.d/slurm_{{ClusterName}}_modulefiles.sh
     state: absent
 
+- name: Unmount /opt/slurm/{{ClusterName}}
+  shell: |
+    set -ex
+
+    # Handle case where cluster was already deleted so the mountpoint is hung
+    if ! timeout 1s /opt/slurm/{{ClusterName}}; then
+        echo "Mount point is hung. Source has already been deleted."
+        umount -lf /opt/slurm/{{ClusterName}}
+    fi
+    if ! mountpoint /opt/slurm/{{ClusterName}}; then
+        echo "/opt/slurm/{{ClusterName}} already unmounted."
+        exit 0
+    fi
+    umount /opt/slurm/{{ClusterName}} || lsof /opt/slurm/{{ClusterName}}
+  register: umount_results
+
+- name: Show umount results
+  debug:
+    msg: |
+      umount_results: {{umount_results}}
+
 - name: Remove /opt/slurm/{{ClusterName}} from /etc/fstab
   mount:
     path: /opt/slurm/{{ClusterName}}

--- a/source/resources/playbooks/roles/install_slurm/README.md
+++ b/source/resources/playbooks/roles/install_slurm/README.md
@@ -1,0 +1,14 @@
+install_slurm
+=========
+
+Compile and install slurm on ParallelCluster NFS share using the Submitter host if the submitter's OS is different than the cluster.
+
+Requirements
+------------
+
+Requires root permissions so that it can install the packages required by slurm.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.

--- a/source/resources/playbooks/roles/install_slurm/tasks/main.yml
+++ b/source/resources/playbooks/roles/install_slurm/tasks/main.yml
@@ -1,0 +1,272 @@
+---
+# tasks file for install_slurm
+
+- name: Show variables used by this role
+  debug:
+    msg: |
+      ansible_architecture:       {{ansible_architecture}}
+      Architecture:               {{Architecture}}
+      distribution:               {{distribution}}
+      distribution_major_version: {{distribution_major_version}}
+      distribution_version:       {{distribution_version}}
+
+      amazonlinux2:   {{amazonlinux2}}
+      alma:           {{alma}}
+      alma8:          {{alma8}}
+      centos:         {{centos}}
+      centos7:        {{centos7}}
+      rhel:           {{rhel}}
+      rhel7:          {{rhel7}}
+      rhel8:          {{rhel8}}
+      rocky:          {{rocky}}
+      rocky8:         {{rocky8}}
+      rhelclone:      {{rhelclone}}
+      rhel8clone:     {{rhel8clone}}
+      centos7_5_to_6: {{centos7_5_to_6}}
+      centos7_5_to_9: {{centos7_5_to_9}}
+      centos7_7_to_9: {{centos7_7_to_9}}
+
+- name: Set variables used by this playbook
+  set_fact:
+    SlurmOSDir:  "/opt/slurm/{{ClusterName}}/config/os/{{distribution}}/{{distribution_major_version}}/{{Architecture}}"
+
+- name: Set variables used by this playbook
+  set_fact:
+    SlurmBinDir: "{{SlurmOSDir}}/bin"
+
+- name: Show variables used by this role
+  debug:
+    msg: |
+      SlurmVersion:       {{SlurmVersion}}
+      SlurmSrcDir:        {{SlurmSrcDir}}
+      SlurmBinDir:        {{SlurmBinDir}}
+      SlurmConfigDir:     {{SlurmConfigDir}}
+      SlurmOSDir:         {{SlurmOSDir}}
+      SlurmrestdPort:     {{SlurmrestdPort}}
+      SlurmEtcDir:        {{SlurmEtcDir}}
+      ModulefilesBaseDir: {{ModulefilesBaseDir}}
+      SubmitterSlurmBaseDir: {{SubmitterSlurmBaseDir}}
+
+- name: Install epel from amazon-linux-extras
+  when: distribution == 'Amazon'
+  shell:
+    cmd: amazon-linux-extras install -y epel
+    creates: /etc/yum.repos.d/epel.repo
+
+- name: Install epel from yum
+  when: distribution in ['CentOS', 'RedHat']
+  yum:
+    state: present
+    name:
+      - epel-release
+
+- name: Enable PowerTools repo
+  when: rhel8clone
+  shell:
+    cmd: yum-config-manager --enable PowerTools || yum-config-manager --enable powertools
+
+- name: Enable rhel-7-server-rhui-optional-rpms
+  when: rhel7
+  shell:
+    cmd: |
+      set -ex
+      yum-config-manager --enable rhel-7-server-rhui-optional-rpms
+      yum-config-manager --enable rhui-REGION-rhel-server-optional
+
+- name: Enable codeready-builder-for-rhel-8-rhui-rpms repo
+  when: rhel8
+  shell:
+    cmd: |
+      yum-config-manager --enable codeready-builder-for-rhel-8-rhui-rpms
+
+- name: Install slurm packages
+  yum:
+    state: present
+    name:
+      - autoconf # To build libjwt
+      - automake # To build libjwt
+      - bzip2
+      - crudini
+      - emacs
+      - freeipmi-devel
+      - fwknop
+      - gcc
+      - git # To build libjwt
+      - gtk2-devel
+      - http-parser-devel
+      - hwloc-devel
+      - jansson-devel # To build libjwt
+      - json-c-devel
+      - libcurl-devel
+      - libtool # To build libjwt
+      - libyaml-devel
+      - lua-devel
+      - lz4-devel
+      - mailx
+      - make
+      - man2html
+      - munge
+      - munge-devel
+      - munge-libs
+      - mysql-devel
+      - numactl-devel
+      - openmpi
+      - openssl-devel # To build libjwt
+      - pam-devel
+      - perl-devel
+      - pmix-devel
+      - python3
+      - readline-devel
+      - rng-tools
+      - rrdtool-devel
+      - wget
+
+- name: Install hdf5-devel
+  when: not(distribution == 'Amazon' and Architecture == 'arm64') and not(rhel8 or rhel8clone)
+  yum:
+    state: present
+    name:
+      - hdf5-devel
+
+- name: Install libjwt-devel on non-Amazon arm64
+  when: not(distribution == 'Amazon' and Architecture == 'arm64')
+  yum:
+    state: present
+    name:
+      - libjwt-devel
+
+- name: Install libjwt-devel on Amazon arm64
+  when: distribution == 'Amazon' and Architecture == 'arm64'
+  shell: |
+    set -xe
+
+    cd /tmp
+    rm -rf libjwt
+    git clone --depth 1 --single-branch -b v1.12.0 https://github.com/benmcollins/libjwt.git libjwt
+    cd libjwt
+    autoreconf --force --install
+    ./configure --prefix=/usr/local
+    make -j
+    make install
+
+- name: Download slurm source
+  shell: |
+    set -xe
+
+    mkdir -p {{SlurmSrcDir}}
+    cd {{SlurmSrcDir}}
+    wget https://download.schedmd.com/slurm/slurm-{{SlurmVersion}}.tar.bz2
+    bzip2 -d -f slurm-{{SlurmVersion}}.tar.bz2
+    tar -xf slurm-{{SlurmVersion}}.tar
+    rm slurm-{{SlurmVersion}}.tar
+
+  args:
+    creates: "{{SlurmSrcDir}}/slurm-{{SlurmVersion}}/INSTALL"
+
+- name: Create {{SlurmOSDir}}
+  file:
+    path: "{{SlurmOSDir}}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0775
+
+- name: Build and install slurm on {{distribution}} {{distribution_major_version}} on {{Architecture}}
+  args:
+    creates: "{{SlurmBinDir}}/srun"
+  shell: |
+    set -xe
+
+    cd {{SlurmSrcDir}}/slurm-{{SlurmVersion}}
+    ./configure --prefix {{SlurmOSDir}}/ --with-slurmrestd --enable-slurmrestd --with-slurmrestd-port={{SlurmrestdPort}} &> configure.log
+    CORES=$(grep processor /proc/cpuinfo | wc -l)
+    make -j $CORES &> slurm-make.log
+    make -j $CORES contrib &> slurm-make-contrib.log
+
+    make install &> slurm-make-install.log
+    make install-contrib &> slurm-make-install-contrib.log
+
+- name: Create {{SlurmEtcDir}}
+  file:
+    path: "{{SlurmEtcDir}}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0775
+
+- name: Create {{SlurmOSDir}}/etc
+  file:
+    state: link
+    src:  "{{SlurmEtcDir}}"
+    path: "{{SlurmOSDir}}/etc"
+    owner: root
+    group: root
+
+- name: Create {{SlurmOSDir}}/etc
+  file:
+    state: link
+    src:  "{{SlurmOSDir}}/lib/libnss_slurm.so.2"
+    path: "/usr/lib64/libnss_slurm.so.2"
+    owner: root
+    group: root
+
+# - name: Enable nss_slurm
+#   lineinfile:
+#     path: /etc/nsswitch.conf
+#     state: present
+#     regexp: '^(passwd:\s+)'
+#     line: '\1nss_slurm sss files systemd'
+#     backrefs: yes
+#     backup: yes
+
+- name: Fix permissions on config dir so users can access it to get the modulefiles
+  file:
+    path: "{{SlurmConfigDir}}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Create {{ModulefilesBaseDir}}/{{distribution}}/{{distribution_major_version}}/{{Architecture}}/{{ClusterName}}
+  file:
+    path: "{{ModulefilesBaseDir}}/{{distribution}}/{{distribution_major_version}}/{{Architecture}}/{{ClusterName}}"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+  register: create_modulefile_dir_result
+
+- name: Fix modulefile permissions
+  when: create_modulefile_dir_result
+  shell:
+    cmd: |
+      set -ex
+
+      chmod -R 0755 {{SlurmConfigDir}}
+
+- name: Create slurm modulefile .template
+  template:
+    dest: "{{ModulefilesBaseDir}}/{{distribution}}/{{distribution_major_version}}/{{Architecture}}/{{ClusterName}}/.template"
+    src:  opt/slurm/config/modules/modulefiles/slurm/.template
+    owner: root
+    group: root
+    mode: '0664'
+    force: yes
+
+- name: Create slurm modulefile
+  file:
+    path: "{{ModulefilesBaseDir}}/{{distribution}}/{{distribution_major_version}}/{{Architecture}}/{{ClusterName}}/{{ParallelClusterVersion}}"
+    src:  ".template"
+    state: link
+    owner: root
+    group: root
+    mode: '0664'
+
+- name: Create slurm modulefile .version
+  template:
+    dest: "{{ModulefilesBaseDir}}/{{distribution}}/{{distribution_major_version}}/{{Architecture}}/{{ClusterName}}/.version"
+    src:   opt/slurm/config/modules/modulefiles/slurm/.version
+    owner: root
+    group: root
+    mode: '0664'
+    force: yes

--- a/source/resources/playbooks/roles/install_slurm/templates/opt/slurm/config/modules/modulefiles/slurm/.template
+++ b/source/resources/playbooks/roles/install_slurm/templates/opt/slurm/config/modules/modulefiles/slurm/.template
@@ -1,0 +1,1 @@
+../../../../../../../../ParallelClusterHeadNode/templates/opt/slurm/modules/modulefiles/slurm/.template

--- a/source/resources/playbooks/roles/install_slurm/templates/opt/slurm/config/modules/modulefiles/slurm/.version
+++ b/source/resources/playbooks/roles/install_slurm/templates/opt/slurm/config/modules/modulefiles/slurm/.version
@@ -1,0 +1,1 @@
+../../../../../../../../ParallelClusterHeadNode/templates/opt/slurm/modules/modulefiles/slurm/.version


### PR DESCRIPTION
So that it can submit jobs to a cluster that uses a different OS.

Automate the configuration of the cluster manager and submitters in RES.

Fix errors in configuration scripts.

Add a parameter to the ParallelCluster custom resource that has a hash of all of the config file contents so that the resource gets updated whenever anything changes.
This current issue with this implementation is that the ParallelCluster still doesn't change so even though the custom resource is updated, the cluster doesn't because it's configuration is unchanged.

Fix a bug in configuring licenses.
After initial configuration the playbook was failing on subsequent updates.

Support custom munge key which must be specified in secretsmanager

Try to allow RES /home to be mounted, but currently causes a validation error.

Resolves #177
Resolves #178
Resolves #180
Resolves #181

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
