### PR TITLE
Relax PyYAML version requirement

### DIFF
--- a/docs/deployment-prerequisites.md
+++ b/docs/deployment-prerequisites.md
@@ -33,6 +33,25 @@ The simplest is to subscribe your email address to the topic so that you get an 
 You could also use it to trigger a CloudWatch alarm that could be used to trigger a lambda to do automatic
 remediation or create a support ticket.
 
+## Make sure using at least python version 3.7
+
+This application requires at least python version 3.7.
+
+Many distributions use older versions of python by default such as python 3.6.8 in RHEL 8 and Rocky Linux 8.
+Newer versions are available, but can't be made the system default without breaking OS tools such as yum.
+The easiest way to get around this is to create a python virtual environment using a newer version of python.
+Simply install the newer version and then use it to create and activate a virtual environment.
+
+```
+$ python3 --version
+Python 3.6.8
+$ yum -y install python3.11
+$ python3.11 -m venv ~/.venv-python3.11
+$ source ~/.venv-python3.11/bin/activate
+$ python3 --version
+Python 3.11.5
+```
+
 ## Make sure required packages are installed
 
 ```

--- a/setup.sh
+++ b/setup.sh
@@ -8,9 +8,6 @@ repodir=$scriptdir
 
 pushd $repodir
 
-# Deactivate any active virtual envs
-deactivate &> /dev/null || true
-
 if ! yum list installed make &> /dev/null; then
     echo -e "\nInstalling make"
     if ! sudo yum -y install make; then
@@ -29,7 +26,7 @@ if ! python3 --version &> /dev/null; then
     echo -e "\nInstalling python3"
     if ! sudo yum -y install python3; then
         echo -e "\nerror: Couldn't find python3 in the path or install it. This is required."
-        exit 1
+        return 1
     fi
 fi
 
@@ -39,14 +36,14 @@ python_major_version=$(echo $python_version | cut -d '.' -f 1)
 python_minor_version=$(echo $python_version | cut -d '.' -f 2)
 if [[ $python_minor_version -lt 7 ]]; then
     echo "error: CDK requires python 3.7 or later. You have $python_version. Update your python3 version."
-    exit 1
+    return 1
 fi
 echo "Using python $python_version"
 
 # Check nodejs version
 required_nodejs_version=16.20.2
 export JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION=1
-if ! node -v &> /dev/null; then
+if ! which node &> /dev/null; then
     echo -e "\nnode not found in your path."
     echo "Installing nodejs in your home dir. Hit ctrl-c to abort"
     pushd $HOME
@@ -68,11 +65,11 @@ node_major_version=$(echo $nodejs_version | cut -d '.' -f 1)
 node_minor_version=$(echo $nodejs_version | cut -d '.' -f 2)
 if [[ $node_major_version -lt 14 ]]; then
     echo "error: CDK requires node 14.15.0 or later. You have $nodejs_version. Update your node version."
-    exit 1
+    return 1
 fi
 if [[ $node_major_version -eq 14 ]] && [[ $node_minor_version -lt 6 ]]; then
     echo "error: CDK requires node 14.15.0 or later. You have $nodejs_version. Update your node version."
-    exit 1
+    return 1
 fi
 if [[ $nodejs_version != $required_nodejs_version ]]; then
     echo "Updating nodejs version from $nodejs_version toe $required_nodejs_version"

--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -10,5 +10,5 @@ pytest
 python-hostlist
 pip
 requests
-PyYAML==5.4.1
+PyYAML>=5.4.1
 schema


### PR DESCRIPTION
Not sure why it was requiring a specific version, but doesn't seem to be necessary.

Update setup.sh

Don't deactivate virtual venv because it can be setting up newer python version.

Use return instead of exit so don't exit calling shell.

Use "which node" instead of "node -v" to detect if nodejs is in the path. "node-v" prompts to install nodejs, which I don't want because I want control over which version is installed.

Resolves #212

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
