### PR TITLE
Add ParallelCluster 3.10.0, 3.10.1 support

### DIFF
--- a/docs/deploy-parallel-cluster.md
+++ b/docs/deploy-parallel-cluster.md
@@ -10,24 +10,6 @@ The current latest version is 3.9.1.
 
 See [Deployment Prerequisites](deployment-prerequisites.md) page.
 
-### Create ParallelCluster UI (optional but recommended)
-
-It is highly recommended to create a ParallelCluster UI to manage your ParallelCluster clusters.
-A different UI is required for each version of ParallelCluster that you are using.
-The versions are list in the [ParallelCluster Release Notes](https://docs.aws.amazon.com/parallelcluster/latest/ug/document_history.html).
-The minimum required version is 3.6.0 which adds support for RHEL 8 and increases the number of allows queues and compute resources.
-The suggested version is at least 3.7.0 because it adds configurable compute node weights which we use to prioritize the selection of
-compute nodes by their cost.
-
-The instructions are in the [ParallelCluster User Guide](https://docs.aws.amazon.com/parallelcluster/latest/ug/install-pcui-v3.html).
-
-### Create ParallelCluster Slurm Database
-
-The Slurm Database is required for configuring Slurm accounts, users, groups, and fair share scheduling.
-It you need these and other features then you will need to create a ParallelCluster Slurm Database.
-You do not need to create a new database for each cluster; multiple clusters can share the same database.
-Follow the directions in this [ParallelCluster tutorial to configure slurm accounting](https://docs.aws.amazon.com/parallelcluster/latest/ug/tutorials_07_slurm-accounting-v3.html#slurm-accounting-db-stack-v3).
-
 ## Create the Cluster
 
 To install the cluster run the install script. You can override some parameters in the config file

--- a/source/resources/playbooks/roles/ParallelClusterSubmitterConfigure/tasks/main.yml
+++ b/source/resources/playbooks/roles/ParallelClusterSubmitterConfigure/tasks/main.yml
@@ -3,10 +3,13 @@
 - name: Show vars used in this playbook
   debug:
     msg: |
-      cluster_name:               {{ cluster_name }}
-      distribution:               {{ distribution }}
-      region:                     {{ region }}
-      slurm_base_dir:             {{ slurm_base_dir }}
+      cluster_name:                   {{ cluster_name }}
+      distribution:                   {{ distribution }}
+      parallel_cluster_munge_version: {{ parallel_cluster_munge_version }}
+      region:                         {{ region }}
+      slurm_base_dir:                 {{ slurm_base_dir }}
+      slurm_config_dir:               {{ slurm_config_dir }}
+      slurm_uid:                      {{ slurm_uid }}
 
 - name: Add /opt/slurm/{{ cluster_name }} to /etc/fstab
   mount:
@@ -53,9 +56,28 @@
     state: present
     create_home: no
 
+
+- name: Get current munge version
+  register: munged_version_output
+  shell: |
+    if ! [ -e /usr/sbin/munged ]; then
+        echo "NONE"
+        exit 0
+    fi
+    /usr/sbin/munged -V | awk '{print $1}'
+
+- set_fact:
+    act_munged_version: "{{ munged_version_output.stdout }}"
+    exp_munged_version: "munge-{{ parallel_cluster_munge_version }}"
+
+- name: Show munged_version
+  debug:
+    msg: |
+      act_munged_version: "{{ act_munged_version }}"
+      exp_munged_version: "{{ exp_munged_version }}"
+
 - name: Build munge version used by ParallelCluster ({{ parallel_cluster_munge_version }})
-  args:
-    creates: /usr/sbin/munged
+  when: act_munged_version != exp_munged_version
   shell: |
     set -ex
 
@@ -116,6 +138,7 @@
     system: yes
     state: present
     create_home: no
+    uid: "{{ slurm_uid }}"
 
 - name: Configure modules
   template:


### PR DESCRIPTION
Add support for ParallelCluster 3.10.0.

Add alinux2023 support.

Add support for external slurmdbd instance.

Update documentation.

Change the UID of the slurm user to 401 to match what ParallelCluster uses. Otherwise munge flags security errors because the UID of the submitter doesn't match the head node.

Change the UpdateHeadNode lambda to only do the update via ssm if the cluster ins't already being updated.

Resolves #242

Change the installer so that it checks to make sure that the cluster stack isn't already being changed or in a bad state.

Resolves #221

Add support for ParallelCluster 3.10.1.

Resolves #243

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
