### PR TITLE
Add support for ParallelCluster 3.11.0

### DIFF
--- a/source/cdk/config_schema.py
+++ b/source/cdk/config_schema.py
@@ -87,6 +87,9 @@ logger.setLevel(logging.INFO)
 #     * Upgrade Python to 3.9.19 (from 3.9.17).
 # 3.10.1:
 #     * Build fix for China regions
+# 3.11.0:
+#     * Add support for ap-southeast-3
+#     * login node enhancements
 MIN_PARALLEL_CLUSTER_VERSION = parse_version('3.6.0')
 # Update source/resources/default_config.yml with latest version when this is updated.
 PARALLEL_CLUSTER_VERSIONS = [
@@ -102,6 +105,7 @@ PARALLEL_CLUSTER_VERSIONS = [
     '3.9.3',
     '3.10.0',
     '3.10.1',
+    '3.11.0',
 ]
 PARALLEL_CLUSTER_MUNGE_VERSIONS = {
     # This can be found on the head node at /opt/parallelcluster/sources
@@ -118,6 +122,7 @@ PARALLEL_CLUSTER_MUNGE_VERSIONS = {
     '3.9.3':   '0.5.15', # confirmed
     '3.10.0':  '0.5.16', # confirmed
     '3.10.1':  '0.5.16', # confirmed
+    '3.11.0':  '0.5.16', #
 }
 PARALLEL_CLUSTER_PYTHON_VERSIONS = {
     # This can be found on the head node at /opt/parallelcluster/pyenv/versions
@@ -133,6 +138,7 @@ PARALLEL_CLUSTER_PYTHON_VERSIONS = {
     '3.9.3':   '3.9.17', # confirmed
     '3.10.0':  '3.9.19', # confirmed
     '3.10.1':  '3.9.19', # confirmed
+    '3.11.0':  '3.9.20', #
 }
 PARALLEL_CLUSTER_SLURM_VERSIONS = {
     # This can be found on the head node at /etc/chef/local-mode-cache/cache/
@@ -148,6 +154,7 @@ PARALLEL_CLUSTER_SLURM_VERSIONS = {
     '3.9.3':   '23.11.7', # confirmed
     '3.10.0':  '23.11.7', # confirmed
     '3.10.1':  '23.11.7', # confirmed
+    '3.11.0':  '23.11.7', #
 }
 PARALLEL_CLUSTER_PC_SLURM_VERSIONS = {
     # This can be found on the head node at /etc/chef/local-mode-cache/cache/
@@ -163,6 +170,7 @@ PARALLEL_CLUSTER_PC_SLURM_VERSIONS = {
     '3.9.3':   '23-11-7-1', # confirmed
     '3.10.0':  '23-11-7-1', # confirmed
     '3.10.1':  '23-11-7-1', # confirmed
+    '3.11.0':  '23-11-10-1', #
 }
 SLURM_REST_API_VERSIONS = {
     '23-02-2-1': '0.0.39',
@@ -173,6 +181,7 @@ SLURM_REST_API_VERSIONS = {
     '23-02-7-1': '0.0.39',
     '23-11-4-1': '0.0.39',
     '23-11-7-1': '0.0.39',
+    '23-11-10-1': '0.0.39',
 }
 
 def get_parallel_cluster_version(config):

--- a/source/cdk/config_schema.py
+++ b/source/cdk/config_schema.py
@@ -107,6 +107,14 @@ PARALLEL_CLUSTER_VERSIONS = [
     '3.10.1',
     '3.11.0',
 ]
+PARALLEL_CLUSTER_ENROOT_VERSIONS = {
+    # This can be found on the head node by running 'yum info enroot'
+    '3.11.0':  '3.4.1', # confirmed
+}
+PARALLEL_CLUSTER_PYXIS_VERSIONS = {
+    # This can be found on the head node at /opt/parallelcluster/sources
+    '3.11.0':  '0.20.0', # confirmed
+}
 PARALLEL_CLUSTER_MUNGE_VERSIONS = {
     # This can be found on the head node at /opt/parallelcluster/sources
     # This can be found on the head node at /etc/chef/local-mode-cache/cache/
@@ -122,7 +130,7 @@ PARALLEL_CLUSTER_MUNGE_VERSIONS = {
     '3.9.3':   '0.5.15', # confirmed
     '3.10.0':  '0.5.16', # confirmed
     '3.10.1':  '0.5.16', # confirmed
-    '3.11.0':  '0.5.16', #
+    '3.11.0':  '0.5.16', # confirmed
 }
 PARALLEL_CLUSTER_PYTHON_VERSIONS = {
     # This can be found on the head node at /opt/parallelcluster/pyenv/versions
@@ -138,7 +146,7 @@ PARALLEL_CLUSTER_PYTHON_VERSIONS = {
     '3.9.3':   '3.9.17', # confirmed
     '3.10.0':  '3.9.19', # confirmed
     '3.10.1':  '3.9.19', # confirmed
-    '3.11.0':  '3.9.20', #
+    '3.11.0':  '3.9.20', # confirmed
 }
 PARALLEL_CLUSTER_SLURM_VERSIONS = {
     # This can be found on the head node at /etc/chef/local-mode-cache/cache/
@@ -154,7 +162,7 @@ PARALLEL_CLUSTER_SLURM_VERSIONS = {
     '3.9.3':   '23.11.7', # confirmed
     '3.10.0':  '23.11.7', # confirmed
     '3.10.1':  '23.11.7', # confirmed
-    '3.11.0':  '23.11.7', #
+    '3.11.0':  '23.11.10', # confirmed
 }
 PARALLEL_CLUSTER_PC_SLURM_VERSIONS = {
     # This can be found on the head node at /etc/chef/local-mode-cache/cache/
@@ -170,7 +178,7 @@ PARALLEL_CLUSTER_PC_SLURM_VERSIONS = {
     '3.9.3':   '23-11-7-1', # confirmed
     '3.10.0':  '23-11-7-1', # confirmed
     '3.10.1':  '23-11-7-1', # confirmed
-    '3.11.0':  '23-11-10-1', #
+    '3.11.0':  '23-11-10-1', # confirmed
 }
 SLURM_REST_API_VERSIONS = {
     '23-02-2-1': '0.0.39',

--- a/source/resources/lambdas/CreateParallelCluster/CreateParallelCluster.py
+++ b/source/resources/lambdas/CreateParallelCluster/CreateParallelCluster.py
@@ -150,8 +150,8 @@ def lambda_handler(event, context):
                 logger.info("Create call succeeded.")
                 logger.info(f"response={response}")
             except Exception as e:
-                logger.exception("ParallelCluster create exception. Ignoring exception so config stack deployment doesn't fail,")
-                message = f"ParallelCluster create exception:\n\n{e}"
+                logger.exception(f"ParallelCluster create exception. Ignoring exception so config stack deployment doesn't fail\n\nException:\n{e}\n\nException dict:\n{e.__dict__}")
+                message = f"ParallelCluster create exception:\n\nException:\n{e}\n\nException dict:\n{e.__dict__}"
                 sns_client.publish(
                     TopicArn = environ['ErrorSnsTopicArn'],
                     Subject = f"{cluster_name} CreateParallelCluster create failed",

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/config-pyxis.yml
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/config-pyxis.yml
@@ -1,0 +1,15 @@
+---
+# APC 3.11.0 added the pyxis Slurm Spank plugin
+# This needs to also be built on login nodes.
+# Currently, I am not doing that so until then, disable the Spank plugin by
+# renaming plugstack.conf
+
+- name: Rename plugstack.conf to plugstack.conf.back
+  shell:
+    cmd: |
+      set -ex
+
+      plugstack_conf=/opt/slurm/etc/plugstack.conf
+      if [[ -e  $plugstack_conf ]]; then
+          mv $plugstack_conf ${plugstack_conf}.back
+      fi

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/main.yml
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/main.yml
@@ -7,3 +7,4 @@
 - { include_tasks: config-slurmrestd.yml, tags: slurmrestd }
 - { include_tasks: config-licenses.yml, tags: licenses }
 - { include_tasks: config-slurmdb-accounts.yml, tags: accounts }
+- { include_tasks: config-pyxis.yml }


### PR DESCRIPTION
Add support for APC 3.11.0.

Disable spack pyxis plug so that external login nodes work.
The spack plugins have to be built on each login node OS and arch.
We rebuild the slurm binaries. Need to build the spack plugins too.

Related to #259 

Resolves #258 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
