### PR TITLE
Only use default EDA excludes if also using default Includes

### DIFF
--- a/source/requirements.txt
+++ b/source/requirements.txt
@@ -10,5 +10,5 @@ pytest
 python-hostlist
 pip
 requests
-PyYAML>=5.4.1
+PyYAML>5.4.1
 schema


### PR DESCRIPTION
Default Exclude only works correctly with default includes because it excludes instance types to keep the total instance types down. If user specifies any includes, then the default EDA excludes may exclude instance types that they are trying to include.
Only use the default EDA includes and excludes if no includes or excludes are configured.

Clean up the defaults to be less opinionated.
For example, don't exclude the a1 instance family even though you probably shouldn't use it.
Don't exclude old instance families even though you probably shouldn't use them.
The defaults should allow anything that is legal.
The defaults will fail because they select too many instance types, but the errors will allow the user
to narrow down the configuration.

The EDA default configuration is opinionated and meant to be a starting point and an example of what is possible.

Resolves #262

Restore memory based partitions.

Related to #235.

Create partitions that include the purchase option (sp|od) and the amoutn of instance memory. This maintains backward compatibility for those using partitions to select the purchase option and amount of total memory.

Resolves #261

Add UseOnDemand configuration option that defaults to true so that you could create a cluster with only spot instances.
Currently you always have to configure on-demand instances and only spot was optional.
Make both purchase options optional, but require at least one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
