### PR TITLE
Support ParallelCluster 3.11.1

### DIFF
--- a/source/cdk/config_schema.py
+++ b/source/cdk/config_schema.py
@@ -90,6 +90,10 @@ logger.setLevel(logging.INFO)
 # 3.11.0:
 #     * Add support for ap-southeast-3
 #     * login node enhancements
+# 3.11.1:
+#     * Disable Pyxis Spack plugin by default
+#     * Upgrade Python runtime to 3.12
+#     * Upgrade libjwt to version 1.17.0.
 MIN_PARALLEL_CLUSTER_VERSION = parse_version('3.6.0')
 # Update source/resources/default_config.yml with latest version when this is updated.
 PARALLEL_CLUSTER_VERSIONS = [
@@ -106,14 +110,17 @@ PARALLEL_CLUSTER_VERSIONS = [
     '3.10.0',
     '3.10.1',
     '3.11.0',
+    '3.11.1',
 ]
 PARALLEL_CLUSTER_ENROOT_VERSIONS = {
     # This can be found on the head node by running 'yum info enroot'
     '3.11.0':  '3.4.1', # confirmed
+    '3.11.1':  '3.4.1', # confirmed
 }
 PARALLEL_CLUSTER_PYXIS_VERSIONS = {
     # This can be found on the head node at /opt/parallelcluster/sources
     '3.11.0':  '0.20.0', # confirmed
+    '3.11.1':  '0.20.0', # confirmed
 }
 PARALLEL_CLUSTER_MUNGE_VERSIONS = {
     # This can be found on the head node at /opt/parallelcluster/sources
@@ -131,6 +138,7 @@ PARALLEL_CLUSTER_MUNGE_VERSIONS = {
     '3.10.0':  '0.5.16', # confirmed
     '3.10.1':  '0.5.16', # confirmed
     '3.11.0':  '0.5.16', # confirmed
+    '3.11.1':  '0.5.16', # confirmed
 }
 PARALLEL_CLUSTER_PYTHON_VERSIONS = {
     # This can be found on the head node at /opt/parallelcluster/pyenv/versions
@@ -147,6 +155,7 @@ PARALLEL_CLUSTER_PYTHON_VERSIONS = {
     '3.10.0':  '3.9.19', # confirmed
     '3.10.1':  '3.9.19', # confirmed
     '3.11.0':  '3.9.20', # confirmed
+    '3.11.1':  '3.9.20', # confirmed
 }
 PARALLEL_CLUSTER_SLURM_VERSIONS = {
     # This can be found on the head node at /etc/chef/local-mode-cache/cache/
@@ -163,6 +172,7 @@ PARALLEL_CLUSTER_SLURM_VERSIONS = {
     '3.10.0':  '23.11.7', # confirmed
     '3.10.1':  '23.11.7', # confirmed
     '3.11.0':  '23.11.10', # confirmed
+    '3.11.1':  '23.11.10', # confirmed
 }
 PARALLEL_CLUSTER_PC_SLURM_VERSIONS = {
     # This can be found on the head node at /etc/chef/local-mode-cache/cache/
@@ -179,6 +189,7 @@ PARALLEL_CLUSTER_PC_SLURM_VERSIONS = {
     '3.10.0':  '23-11-7-1', # confirmed
     '3.10.1':  '23-11-7-1', # confirmed
     '3.11.0':  '23-11-10-1', # confirmed
+    '3.11.1':  '23-11-10-1', # confirmed
 }
 SLURM_REST_API_VERSIONS = {
     '23-02-2-1': '0.0.39',

--- a/source/resources/lambdas/CreateBuildFiles/CreateBuildFiles.py
+++ b/source/resources/lambdas/CreateBuildFiles/CreateBuildFiles.py
@@ -139,6 +139,10 @@ def lambda_handler(event, context):
             else:
                 raise KeyError(error_message)
 
+        if requestType == 'Delete':
+            cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId=cluster_name)
+            return
+
         ami_builds = json.loads(environ['AmiBuildsJson'])
         assets_bucket = environ['AssetsBucket']
         assets_base_key = environ['AssetsBaseKey']

--- a/source/resources/parallel-cluster/config/bin/on_compute_node_configured.sh
+++ b/source/resources/parallel-cluster/config/bin/on_compute_node_configured.sh
@@ -63,7 +63,9 @@ fi
 export PATH=/usr/sbin:$PATH
 
 echo "Creating users and groups"
-$config_bin_dir/create_users_groups.py -i $config_dir/users_groups.json
+if [[ -e $config_dir/users_groups.json ]]; then
+    $config_bin_dir/create_users_groups.py -i $config_dir/users_groups.json
+fi
 
 # ansible_compute_node_vars_yml_s3_url="s3://$assets_bucket/$assets_base_key/config/ansible/ansible_compute_node_vars.yml"
 

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/config-submitter-access.yml
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/config-submitter-access.yml
@@ -35,12 +35,14 @@
     cmd: |
       set -ex
 
-      conf_files=$(find /opt/slurm -name '*.conf')
+      conf_files=$(find /opt/slurm/etc -name '*.conf')
       backup_suffix=".$(date '+%Y-%m-%dT%H:%M:%S')~"
       num_changed=0
       for conf_file in ${conf_files[*]}; do
-          sed --in-place=$backup_suffix 's%/opt/slurm/etc%/opt/slurm/{{ cluster_name }}/etc%' $conf_file
-          sed --in-place=$backup_suffix 's%/opt/slurm/lib%/opt/slurm/{{ cluster_name }}/lib%' $conf_file
+          sed --in-place=$backup_suffix \
+              -e 's%/opt/slurm/etc%/opt/slurm/{{ cluster_name }}/etc%' \
+              -e 's%/opt/slurm/lib%/opt/slurm/{{ cluster_name }}/lib%' \
+              $conf_file
 
           backup_conf_file="${conf_file}${backup_suffix}"
           if diff -q $backup_conf_file $conf_file; then
@@ -56,6 +58,12 @@
       else
           echo "No conf files changed."
       fi
+  register: change_slurm_conf_result
+
+- name: Show change_slurm_conf_result
+  debug:
+    msg: |
+      {{ change_slurm_conf_result }}
 
 - name: Fix permissions on config dir so users can access it to get the modulefiles
   file:

--- a/source/resources/playbooks/roles/exostellar_infrastructure_optimizer/files/opt/slurm/etc/exostellar/configure_xio.py
+++ b/source/resources/playbooks/roles/exostellar_infrastructure_optimizer/files/opt/slurm/etc/exostellar/configure_xio.py
@@ -23,8 +23,6 @@ from io import BytesIO
 import json
 import logging
 import logging.handlers
-import os
-import pycurl
 import requests
 import yaml
 

--- a/source/resources/playbooks/roles/exostellar_infrastructure_optimizer/tasks/main.yml
+++ b/source/resources/playbooks/roles/exostellar_infrastructure_optimizer/tasks/main.yml
@@ -143,6 +143,8 @@
     cmd: |
       set -ex
 
+      yum -y install python3.11-pip
+      python3.11 -m pip install requests PyYaml
       {{ exostellar_dir }}/configure_xio.py
 
 - name: Create {{ exostellar_dir }}/xspot.slurm.conf


### PR DESCRIPTION
Require at least 4 GB or else instance doesn't have enough memory.

Update Lambdas to Python 3.12 from 3.9.

Resolves #268

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
