### PR TITLE
Set RealMemory to the actual total instance memory.

### DIFF
--- a/source/cdk/cdk_slurm_stack.py
+++ b/source/cdk/cdk_slurm_stack.py
@@ -2723,7 +2723,8 @@ class CdkSlurmStack(Stack):
                         continue
                 logger.debug(f"Creating queue for {purchase_option} {instance_type}")
                 efa_supported = self.plugin.get_EfaSupported(self.cluster_region, instance_type) and self.config['slurm']['ParallelClusterConfig']['EnableEfa']
-                mem_gb = int(self.plugin.get_MemoryInMiB(self.cluster_region, instance_type) / 1024)
+                mem_mb = self.plugin.get_MemoryInMiB(self.cluster_region, instance_type)
+                mem_gb = int(mem_mb / 1024)
                 core_count = int(self.plugin.get_CoreCount(self.cluster_region, instance_type))
                 threads_per_core = int(self.plugin.get_DefaultThreadsPerCore(self.cluster_region, instance_type))
                 if not instance_type_config['DisableSimultaneousMultithreading']:
@@ -2784,6 +2785,7 @@ class CdkSlurmStack(Stack):
                     max_count = self.config['slurm']['InstanceConfig']['NodeCounts']['DefaultMaxCount']
                 compute_resource = {
                     'Name': compute_resource_name,
+                    'SchedulableMemory': mem_mb,
                     'MinCount': min_count,
                     'MaxCount': max_count,
                     'DisableSimultaneousMultithreading': instance_type_config['DisableSimultaneousMultithreading'],


### PR DESCRIPTION
The default is to set it to 95% which makes it difficult to correctly request memory because you could submit a job and request 4GB and wind up running on an 8GB machine.

This just makes it more intuitive.

Resolves #283

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
