### PR TITLE
Fix Slurmdbd security group rules from external login node

### DIFF
--- a/create-slurm-security-groups/create-slurm-security-groups.py
+++ b/create-slurm-security-groups/create-slurm-security-groups.py
@@ -100,10 +100,15 @@ class CreateSlurmSecurityGroups():
                         slurmdbd_security_group_id = stack_resource_summary_dict['PhysicalResourceId']
                         break
                 if slurmdbd_security_group_id:
+                    self.stack_parameters['slurmdbd_security_group_id'] = slurmdbd_security_group_id
                     break
             if not slurmdbd_security_group_id:
                 logger.error(f"SlurmdbdServerSecurityGroup resource not found in {args.slurmdbd_stack_name} stack.")
                 exit(1)
+
+        if args.slurmdbd_security_group_id and slurmdbd_security_group_id and (args.slurmdbd_security_group_id != slurmdbd_security_group_id):
+            logger.error(f"Both --slurmdbd-stack-name and --slurmdbd-security-group-id are set and they don't match.")
+            exit(1)
 
         if args.slurmdbd_security_group_id:
             self.stack_parameters['slurmdbd_security_group_id'] = args.slurmdbd_security_group_id


### PR DESCRIPTION
If --slurmdbd-stack-name is set, the security group id wasn't being passed to the cdk stack so access from login node wasn't allowed.

Resolves #288 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
