### PR TITLE
Add support for ParallelCluster 3.12.0

### DIFF
--- a/create-slurm-security-groups/create-slurm-security-groups.py
+++ b/create-slurm-security-groups/create-slurm-security-groups.py
@@ -61,6 +61,7 @@ class CreateSlurmSecurityGroups():
         parser.add_argument("--fsxo-security-group-id", type=str, help="Id of security group attached to FSx for NetApp Ontap file systems.")
         parser.add_argument("--fsxz-security-group-id", type=str, help="Id of security group attached to FSx for OpenZfs file systems.")
         parser.add_argument("--cdk-cmd", type=str, choices=["deploy", "create", "update", "diff", "ls", "list", "synth", "synthesize", "destroy", "bootstrap"], default="create")
+        parser.add_argument("--min-pc-version", type=str, default="3.12.0", help="Minimum version of ParallelCluster being used. Used to control security group rules required by PC.")
         parser.add_argument("--debug", action='store_const', const=True, default=False, help="Enable CDK debug mode")
         args = parser.parse_args()
 
@@ -72,6 +73,9 @@ class CreateSlurmSecurityGroups():
         # Choose region
         # Must be passed to the stack.
         self.stack_parameters['region'] = args.region
+
+        logger.debug(f"min pc version: {args.min_pc_version}")
+        self.stack_parameters['min_parallel_cluster_version'] = args.min_pc_version
 
         # Retrieve the AWS Account ID for CDK
         sts_client = boto3.client("sts", region_name=args.region)

--- a/create-slurm-security-groups/requirements.txt
+++ b/create-slurm-security-groups/requirements.txt
@@ -2,3 +2,4 @@ aws-cdk-lib==2.111.0
 boto3
 colored
 constructs>=10.0.0,<11.0.0
+packaging

--- a/source/cdk/config_schema.py
+++ b/source/cdk/config_schema.py
@@ -97,6 +97,8 @@ logger.setLevel(logging.INFO)
 #     * Disable Pyxis Spack plugin by default
 #     * Upgrade Python runtime to 3.12
 #     * Upgrade libjwt to version 1.17.0.
+# 3.12.0:
+#     * OpenZFS security group requirements fixed.
 MIN_PARALLEL_CLUSTER_VERSION = parse_version('3.6.0')
 # Update source/resources/default_config.yml with latest version when this is updated.
 PARALLEL_CLUSTER_VERSIONS = [
@@ -114,16 +116,19 @@ PARALLEL_CLUSTER_VERSIONS = [
     '3.10.1',
     '3.11.0',
     '3.11.1',
+    '3.12.0',
 ]
 PARALLEL_CLUSTER_ENROOT_VERSIONS = {
     # This can be found on the head node by running 'yum info enroot'
     '3.11.0':  '3.4.1', # confirmed
     '3.11.1':  '3.4.1', # confirmed
+    '3.12.0':  '3.4.1', # confirmed
 }
 PARALLEL_CLUSTER_PYXIS_VERSIONS = {
     # This can be found on the head node at /opt/parallelcluster/sources
     '3.11.0':  '0.20.0', # confirmed
     '3.11.1':  '0.20.0', # confirmed
+    '3.12.0':  '0.20.0', # confirmed
 }
 PARALLEL_CLUSTER_MUNGE_VERSIONS = {
     # This can be found on the head node at /opt/parallelcluster/sources
@@ -142,6 +147,7 @@ PARALLEL_CLUSTER_MUNGE_VERSIONS = {
     '3.10.1':  '0.5.16', # confirmed
     '3.11.0':  '0.5.16', # confirmed
     '3.11.1':  '0.5.16', # confirmed
+    '3.12.0':  '0.5.16', # confirmed
 }
 PARALLEL_CLUSTER_PYTHON_VERSIONS = {
     # This can be found on the head node at /opt/parallelcluster/pyenv/versions
@@ -159,6 +165,7 @@ PARALLEL_CLUSTER_PYTHON_VERSIONS = {
     '3.10.1':  '3.9.19', # confirmed
     '3.11.0':  '3.9.20', # confirmed
     '3.11.1':  '3.9.20', # confirmed
+    '3.12.0':  '3.9.20', # confirmed
 }
 PARALLEL_CLUSTER_SLURM_VERSIONS = {
     # This can be found on the head node at /etc/chef/local-mode-cache/cache/
@@ -176,6 +183,7 @@ PARALLEL_CLUSTER_SLURM_VERSIONS = {
     '3.10.1':  '23.11.7', # confirmed
     '3.11.0':  '23.11.10', # confirmed
     '3.11.1':  '23.11.10', # confirmed
+    '3.12.0':  '23.11.10', # confirmed
 }
 PARALLEL_CLUSTER_PC_SLURM_VERSIONS = {
     # This can be found on the head node at /etc/chef/local-mode-cache/cache/
@@ -193,6 +201,7 @@ PARALLEL_CLUSTER_PC_SLURM_VERSIONS = {
     '3.10.1':  '23-11-7-1', # confirmed
     '3.11.0':  '23-11-10-1', # confirmed
     '3.11.1':  '23-11-10-1', # confirmed
+    '3.12.0':  '23-11-10-1', # confirmed
 }
 SLURM_REST_API_VERSIONS = {
     '23-02-2-1': '0.0.39',
@@ -328,6 +337,14 @@ def get_PARALLEL_CLUSTER_LAMBDA_RUNTIME(parallel_cluster_version):
         return aws_lambda.Runtime.PYTHON_3_9
     else:
         return aws_lambda.Runtime.PYTHON_3_12
+
+# Version 3.12.0
+
+def PARALLEL_CLUSTER_REQUIRES_FSXZ_OUTBOUND_SG_RULES(parallel_cluster_version):
+    if parallel_cluster_version < parse_version('3.12.0'):
+        return True
+    else:
+        return False
 
 # Determine all AWS regions available on the account.
 default_region = environ.get("AWS_DEFAULT_REGION", "us-east-1")


### PR DESCRIPTION
Resolves #295

Update the FSxZ security groups to remove outbound security group rules.

Resolves #253

Update the installer to check the status of the ParallelCluster stack after the config stack update is complete.
Make sure that the stack exists and that it was correctly deployed or else give an error message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
