### PR TITLE
Enable ena-express

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -1,0 +1,1 @@
+key = 'ParallelClusterEnableEnaExpressPolicyArn'

--- a/docs/config.md
+++ b/docs/config.md
@@ -108,12 +108,16 @@ This project creates a ParallelCluster configuration file that is documented in 
                 useOnDemand: bool
                 UseSpot: bool
                 DisableSimultaneousMultithreading: bool
+                EnableEfa: bool
+                PlacementGroupName: str
             <a href="#include-instancetypes">InstanceTypes</a>:
             - str
             - str:
                 UseOnDemand: bool
                 UseSpot: bool
                 DisableSimultaneousMultithreading: bool
+                EnableEfa: bool
+                PlacementGroupName: str
         <a href="#nodecounts">NodeCounts</a>:
             <a href="#defaultmincount">DefaultMinCount</a>: str
             <a href="#defaultmaxcount">DefaultMaxCount</a>: str
@@ -373,7 +377,14 @@ type: bool
 
 default: False
 
-Recommend to not use EFA unless necessary to avoid insufficient capacity errors when starting new instances in group or when multiple instance types in the group.
+This will enable EFA for all compute resources with instances that support EFA.
+
+This can also be controlled for individual instance types in the InstanceConfig section.
+
+If EFA is enabled without specifying a placement group name, then each compute resource is assigned its own managed placement group.
+
+NOTE: Most EDA workloads cannot take advantage of EFA because they don't use MPI or NCCL.
+I recommend to not use EFA unless necessary to avoid insufficient capacity errors when starting new instances in group or when multiple instance types are in the group.
 
 See [https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#placement-groups-cluster](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#placement-groups-cluster)
 
@@ -827,7 +838,7 @@ Exclude patterns are processed first and take precedence over any includes.
 Instance families and types are regular expressions with implicit '^' and '$' at the begining and end.
 
 Each element in the array can be either a regular expression string or a dictionary where the only key
-is the regular expression string and that has overrides **UseOnDemand**, **UseSpot**, and **DisableSimultaneousMultithreading** for the matching instance families or instance types.
+is the regular expression string and that has overrides **UseOnDemand**, **UseSpot**, **DisableSimultaneousMultithreading**, **EnableEfa**, and **PlacementGroupName** for the matching instance families or instance types.
 
 The settings for instance families overrides the defaults, and the settings for instance types override the others.
 

--- a/source/EC2InstanceTypeInfoPkg/get_ec2_instance_info.py
+++ b/source/EC2InstanceTypeInfoPkg/get_ec2_instance_info.py
@@ -5,6 +5,7 @@ from botocore.exceptions import NoCredentialsError
 from EC2InstanceTypeInfoPkg.EC2InstanceTypeInfo import EC2InstanceTypeInfo
 import logging
 from sys import exit
+from VersionCheck import logger as VersionCheck_logger, VersionCheck
 
 if __name__ == '__main__':
     try:
@@ -12,8 +13,15 @@ if __name__ == '__main__':
         parser.add_argument("--region", "-r", type=str, default=[], action='append', help="AWS region(s) to get info for.")
         parser.add_argument("--input", '-i', type=str, default=None, help="JSON input file. Reads existing info from previous runs. Can speed up rerun if it failed to collect the data for a region.")
         parser.add_argument("--output-csv", '-o', type=str, default=None, help="CSV output file. Default: instance_type_info.csv")
+        parser.add_argument("--disable-version-check", action='store_const', const=True, default=False, help="Disable git version check")
         parser.add_argument("--debug", "-d", action='store_const', const=True, default=False, help="Enable debug messages")
         args = parser.parse_args()
+
+        if args.debug:
+            VersionCheck_logger.setLevel(logging.DEBUG)
+
+        if not args.disable_version_check and not VersionCheck().check_git_version():
+            exit(1)
 
         if args.input:
             print(f"Reading existing instance info from {args.input}")

--- a/source/EC2InstanceTypeInfoPkg/retry_boto3_throttling.py
+++ b/source/EC2InstanceTypeInfoPkg/retry_boto3_throttling.py
@@ -63,11 +63,11 @@ def retry_boto3_throttling(min_delay = 1, max_delay = 10 * 60, max_cumulative_de
                     attempt += 1
                     return f(*args, **kwargs)
                 except ClientError as e:
-                    logging.exception("Caught exception")
+                    logging.debug("Caught exception")
                     if e.response['Error']['Code'] in ['RequestLimitExceeded', 'InternalError', 'ThrottlingException']:
                         pass
                     else:
-                        logging.exception("Rethrew exception")
+                        logging.debug("Rethrew exception")
                         raise e
                     logger.debug("%s" % (traceback.format_exc()))
                     logger.debug("attempt=%d" % attempt)

--- a/source/SlurmPlugin.py
+++ b/source/SlurmPlugin.py
@@ -1964,7 +1964,9 @@ class SlurmPlugin:
         default_instance_type_config = {
             'UseOnDemand': instance_config['UseOnDemand'],
             'UseSpot': instance_config['UseSpot'],
-            'DisableSimultaneousMultithreading': instance_config['DisableSimultaneousMultithreading']
+            'DisableSimultaneousMultithreading': instance_config['DisableSimultaneousMultithreading'],
+            'EnableEfa': instance_config['EnableEfa'],
+            'PlacementGroupName': instance_config.get('PlacementGroupName', None)
         }
 
         instance_types = {}
@@ -2069,6 +2071,8 @@ class SlurmPlugin:
                     instance_type_config['UseOnDemand'] = instance_type_config.get('UseOnDemand', instance_family_config.get('UseOnDemand', default_instance_type_config['UseOnDemand']))
                     instance_type_config['UseSpot'] = instance_type_config.get('UseSpot', instance_family_config.get('UseSpot', default_instance_type_config['UseSpot']))
                     instance_type_config['DisableSimultaneousMultithreading'] = instance_type_config.get('DisableSimultaneousMultithreading', instance_family_config.get('DisableSimultaneousMultithreading', default_instance_type_config['DisableSimultaneousMultithreading']))
+                    instance_type_config['EnableEfa'] = instance_type_config.get('EnableEfa', instance_family_config.get('EnableEfa', default_instance_type_config['EnableEfa']))
+                    instance_type_config['PlacementGroupName'] = instance_type_config.get('PlacementGroupName', instance_family_config.get('PlacementGroupName', default_instance_type_config['PlacementGroupName']))
 
                     region_instance_types[instance_type] = instance_type_config
 

--- a/source/cdk/config_schema.py
+++ b/source/cdk/config_schema.py
@@ -1530,9 +1530,6 @@ def get_config_schema(config):
                 },
                 Optional('Architecture', default=DEFAULT_ARCHITECTURE): And(str, lambda s: s in VALID_ARCHITECTURES),
                 Optional('ComputeNodeAmi'): And(str, lambda s: s.startswith('ami-')),
-                # Recommend to not use EFA unless necessary to avoid insufficient capacity errors when starting new instances in group or when multiple instance types in the group
-                # See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#placement-groups-cluster
-                Optional('EnableEfa', default=False): bool,
                 Optional('Database'): {
                     Optional('DatabaseStackName'): str,
                     Optional('FQDN'): str,
@@ -1641,6 +1638,11 @@ def get_config_schema(config):
                 #     Configure spot instances
                 Optional('UseSpot', default=True): bool,
                 Optional('DisableSimultaneousMultithreading', default=True): bool,
+                # This is a global setting that can be overridden for instance types in InstanceConfig.
+                # Recommend to not use EFA unless necessary to avoid insufficient capacity errors when starting new instances in group or when multiple instance types in the group
+                # See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#placement-groups-cluster
+                Optional('EnableEfa', default=False): bool,
+                Optional('PlacementGroupName'): str,
                 Optional('CpuVendor', default=cpu_vendors): [
                     And(str, lambda s: s in cpu_vendors)
                 ],
@@ -1665,7 +1667,9 @@ def get_config_schema(config):
                                     str: {
                                         Optional('UseOnDemand'): bool,
                                         Optional('UseSpot'): bool,
-                                        Optional('DisableSimultaneousMultithreading'): bool
+                                        Optional('DisableSimultaneousMultithreading'): bool,
+                                        Optional('EnableEfa'): bool,
+                                        Optional('PlacementGroupName'): str
                                     }
                                 },
                                 lambda d: len(d) == 1
@@ -1680,7 +1684,9 @@ def get_config_schema(config):
                                     str: {
                                         Optional('UseOnDemand'): bool,
                                         Optional('UseSpot'): bool,
-                                        Optional('DisableSimultaneousMultithreading'): bool
+                                        Optional('DisableSimultaneousMultithreading'): bool,
+                                        Optional('EnableEfa'): bool,
+                                        Optional('PlacementGroupName'): str
                                     }
                                 },
                                 lambda d: len(d) == 1

--- a/source/resources/parallel-cluster/config/bin/on_compute_node_configured.sh
+++ b/source/resources/parallel-cluster/config/bin/on_compute_node_configured.sh
@@ -71,6 +71,12 @@ if [[ -e $config_dir/users_groups.json ]]; then
     $config_bin_dir/create_users_groups.py -i $config_dir/users_groups.json
 fi
 
+# Enable ENA Express
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+mac=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/network/interfaces/macs/)
+eni_id=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/network/interfaces/macs/${mac}interface-id/)
+aws ec2 modify-network-interface-attribute --network-interface-id ${eni_id} --ena-srd-specification 'EnaSrdEnabled=true,EnaSrdUdpSpecification={EnaSrdUdpEnabled=true}'
+
 # ansible_compute_node_vars_yml_s3_url="s3://$assets_bucket/$assets_base_key/config/ansible/ansible_compute_node_vars.yml"
 
 # # Configure using ansible


### PR DESCRIPTION
Detect that instances can support ENA-Express and enable it so that they have more networking bandwith.

Note that the AMI must have the correct drivers installed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
