### PR TITLE
Update deconfigure scripts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
     "files.trimTrailingWhitespace": true,
     "files.watcherExclude": {
         "**/cdk.out": true
-    }
+    },
+    "makefile.configureOnOpen": false
 }

--- a/source/cdk/cdk_slurm_stack.py
+++ b/source/cdk/cdk_slurm_stack.py
@@ -3173,7 +3173,7 @@ class CdkSlurmStack(Stack):
         region = self.cluster_region
         cluster_name = self.config['slurm']['ClusterName']
         CfnOutput(self, "Command01_MountHeadNodeNfs",
-            value = f"head_ip=head_node.{self.config['slurm']['ClusterName']}.pcluster && sudo mkdir -p /opt/slurm/{cluster_name} && sudo mount $head_ip:/opt/slurm /opt/slurm/{cluster_name}"
+            value = f"head_ip=head_node.{self.config['slurm']['ClusterName']}.pcluster && sudo mkdir -p /opt/slurm/{cluster_name} && sudo mount $head_ip:/opt/slurm /opt/slurm/{cluster_name} && sudo systemctl daemon-reload"
         )
         CfnOutput(self, "Command02_CreateUsersGroupsJsonConfigure",
             value = f"sudo /opt/slurm/{cluster_name}/config/bin/create_users_groups_json_configure.sh"
@@ -3182,10 +3182,10 @@ class CdkSlurmStack(Stack):
             value = f"sudo /opt/slurm/{cluster_name}/config/bin/external_login_node_configure.sh"
         )
         CfnOutput(self, "command10_CreateUsersGroupsJsonDeconfigure",
-            value = f"sudo /opt/slurm/{cluster_name}/config/bin/create_users_groups_json_deconfigure.sh"
+            value = f"sudo /opt/aws-eda-slurm-cluster/{cluster_name}/bin/create_users_groups_json_deconfigure.sh"
         )
         CfnOutput(self, "command11_ExternalLoginNodeDeconfigure",
-            value = f"sudo /opt/slurm/{cluster_name}/config/bin/external_login_nodes_deconfigure.sh && sudo umount /opt/slurm/{cluster_name}"
+            value = f"sudo /opt/aws-eda-slurm-cluster/{cluster_name}/bin/external_login_node_deconfigure.sh"
         )
 
     def create_queue_config(self, queue_name, allocation_strategy, purchase_option):

--- a/source/resources/lambdas/DeconfigureExternalLoginNodes/DeconfigureExternalLoginNodes.py
+++ b/source/resources/lambdas/DeconfigureExternalLoginNodes/DeconfigureExternalLoginNodes.py
@@ -118,46 +118,9 @@ def lambda_handler(event, context):
         ssm_script = dedent(f"""
             set -ex
 
-            mount_dest=/opt/slurm/{cluster_name}
+            script="/opt/aws-eda-slurm-cluster/{cluster_name}/bin/external_login_node_deconfigure.sh"
+            sudo $script
 
-            # Make sure that the cluster is still mounted and mount is accessible.
-            # If the cluster has already been deleted then the mount will be hung and we have to do manual cleanup.
-            if mount | grep " $mount_dest "; then
-                echo "$mount_dest is mounted."
-                if ! timeout 1s ls $mount_dest; then
-                    echo "Mount point ($mount_dest) is hung. Source may have already been deleted."
-                    timeout 5s sudo umount -lf $mount_dest
-                    timeout 1s rm -rf $mount_dest
-                fi
-            fi
-
-            script="$mount_dest/config/bin/external_login_node_deconfigure.sh"
-            if ! timeout 1s ls $script; then
-                echo "$script doesn't exist"
-            else
-                sudo $script
-            fi
-
-            # Do manual cleanup just in case something above failed.
-
-            sudo rm -f /etc/profile.d/slurm_{cluster_name}_modulefiles.sh
-
-            sudo grep -v ' $mount_dest ' /etc/fstab > /etc/fstab.new
-            if diff -q /etc/fstab /etc/fstab.new; then
-                sudo rm -f /etc/fstab.new
-            else
-                sudo cp /etc/fstab /etc/fstab.$(date '+%Y-%m-%d@%H:%M:%S~')
-                sudo mv -f /etc/fstab.new /etc/fstab
-            fi
-
-            if timeout 1s mountpoint $mount_dest; then
-                echo "$mount_dest is a mountpoint"
-                sudo umount -lf $mount_dest
-            fi
-
-            if timeout 1s ls $mount_dest; then
-                sudo rmdir $mount_dest
-            fi
             """)
 
         response = ssm_client.send_command(

--- a/source/resources/parallel-cluster/config/bin/create_users_groups_json_configure.sh
+++ b/source/resources/parallel-cluster/config/bin/create_users_groups_json_configure.sh
@@ -4,16 +4,39 @@
 
 # This script creates the json file with user and group information.
 # It also creates a crontab entry to update the json file every hour.
+#
+# The script and ansible playbooks needed to undo this will be installed at:
+#
+# /opt/aws-eda-slurm-cluster/{{ cluster_name }}
+#
+# To deconfigure the instance, run the following script:
+#
+# /opt/aws-eda-slurm-cluster/{{ cluster_name }}/create_users_groups_json_deconfigure.sh
 
 full_script=$(realpath $0)
 script_dir=$(dirname $full_script)
 base_script=$(basename $full_script)
 
-date
-echo "Started create_users_groups_json_configure.sh: $full_script"
+echo "$(date): Started create_users_groups_json_configure.sh: $full_script"
 
 config_dir={{ ExternalLoginNodeSlurmConfigDir }}
 config_bin_dir=$config_dir/bin
+
+ErrorSnsTopicArn={{ ErrorSnsTopicArn }}
+
+# Notify user of errors
+function on_exit {
+    rc=$?
+    set +e
+    if [[ $rc -ne 0 ]] && [[ ":$ErrorSnsTopicArn" != ":" ]]; then
+        message_file=$(mktemp)
+        echo "See log files for more info:
+    grep ${script_name} /var/log/messages | less" > $message_file
+        aws sns publish --topic-arn $ErrorSnsTopicArn --subject "${ClusterName} ${script_name} failed" --message file://$message_file
+        rm $message_file
+    fi
+}
+trap on_exit EXIT
 
 # Configure using ansible
 if ! yum list installed ansible &> /dev/null; then
@@ -29,7 +52,6 @@ ansible-playbook $PLAYBOOKS_PATH/ParallelClusterCreateUsersGroupsJsonConfigure.y
     -e @$ANSIBLE_PATH/ansible_external_login_node_vars.yml
 popd
 
-date
-echo "Finished create_users_groups_json_configure.sh: $full_script"
+echo "$(date): Finished create_users_groups_json_configure.sh: $full_script"
 
 exit 0

--- a/source/resources/parallel-cluster/config/bin/external_login_node_configure.sh
+++ b/source/resources/parallel-cluster/config/bin/external_login_node_configure.sh
@@ -2,6 +2,16 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
+# This script configures an instance as an external login node for a ParallelCluster cluster.
+#
+# The script and ansible playbooks needed to undo this will be installed at:
+#
+# /opt/aws-eda-slurm-cluster/{{ cluster_name }}
+#
+# To deconfigure the instance as a login node run the following script:
+#
+# /opt/aws-eda-slurm-cluster/{{ cluster_name }}/external_login_node_deconfigure.sh
+
 full_script=$(realpath $0)
 script_dir=$(dirname $full_script)
 script_name=$(basename $full_script)

--- a/source/resources/parallel-cluster/config/bin/external_login_node_deconfigure.sh
+++ b/source/resources/parallel-cluster/config/bin/external_login_node_deconfigure.sh
@@ -2,33 +2,39 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
+# This script deconfigures an instance that has been configured as a ParallelCluster Slurm login node.
+#
+# This script and it's ansible playbook are copied to /opt/aws-eda-slurm-cluster/{{ cluster_name }} so
+# that they can be executed whether the cluster still exists or not.
+
 full_script=$(realpath $0)
 script_dir=$(dirname $full_script)
 base_script=$(basename $full_script)
+ANSIBLE_PATH=$(dirname $script_dir)/ansible
+PLAYBOOKS_PATH=$ANSIBLE_PATH/playbooks
 
-date
-echo "Started external_login_node_deconfigure.sh: $full_script"
+echo "$(date): Started $base_script: $full_script"
 
 ErrorSnsTopicArn={{ ErrorSnsTopicArn }}
 
-config_dir={{ ExternalLoginNodeSlurmConfigDir }}
-config_bin_dir=$config_dir/bin
-
-temp_config_dir=/tmp/{{ClusterName}}_config
-temp_config_bin_dir=$temp_config_dir/bin
-if [[ $script_dir != $temp_config_bin_dir ]]; then
-    rm -rf $temp_config_dir
-    cp -r $config_dir $temp_config_dir
-    exec $temp_config_dir/bin/$base_script
-fi
+# Notify user of errors
+function on_exit {
+    rc=$?
+    set +e
+    if [[ $rc -ne 0 ]] && [[ ":$ErrorSnsTopicArn" != ":" ]]; then
+        message_file=$(mktemp)
+        echo "See log files for more info:
+    grep ${script_name} /var/log/messages | less" > $message_file
+        aws sns publish --topic-arn $ErrorSnsTopicArn --subject "${ClusterName} ${script_name} failed" --message file://$message_file
+        rm $message_file
+    fi
+}
+trap on_exit EXIT
 
 # Install ansible
 if ! yum list installed ansible &> /dev/null; then
     yum install -y ansible || amazon-linux-extras install -y ansible2
 fi
-
-ANSIBLE_PATH=$temp_config_dir/ansible
-PLAYBOOKS_PATH=$ANSIBLE_PATH/playbooks
 
 pushd $PLAYBOOKS_PATH
 ansible-playbook $PLAYBOOKS_PATH/ParallelClusterExternalLoginNodeDeconfigure.yml \
@@ -36,9 +42,8 @@ ansible-playbook $PLAYBOOKS_PATH/ParallelClusterExternalLoginNodeDeconfigure.yml
     -e @$ANSIBLE_PATH/ansible_external_login_node_vars.yml
 popd
 
-rm -rf $temp_config_dir
+rm -rf $(dirname $script_dir)
 
-date
-echo "Finished external_login_node_deconfigure.sh: $full_script"
+echo "$(date): Finished $base_script: $full_script"
 
 exit 0

--- a/source/resources/playbooks/roles/ParallelClusterCreateUsersGroupsJsonConfigure/tasks/main.yml
+++ b/source/resources/playbooks/roles/ParallelClusterCreateUsersGroupsJsonConfigure/tasks/main.yml
@@ -32,3 +32,40 @@
     group: root
     mode: 0600
     force: yes
+
+- name: Create /opt/aws-eda-slurm-cluster/{{ cluster_name }}
+  file:
+    path: /opt/aws-eda-slurm-cluster/{{ cluster_name }}
+    owner: root
+    group: root
+    mode: 0700
+    state: directory
+
+- name: Create /opt/aws-eda-slurm-cluster/{{ cluster_name }}/bin
+  file:
+    path: /opt/aws-eda-slurm-cluster/{{ cluster_name }}/bin
+    owner: root
+    group: root
+    mode: 0700
+    state: directory
+
+- name: Copy {{ slurm_config_dir }}/bin/create_users_groups_json_deconfigure.sh to /opt/aws-eda-slurm-cluster/{{ cluster_name }}/bin/
+  copy:
+    src: "{{ slurm_config_dir }}/bin/create_users_groups_json_deconfigure.sh"
+    dest: /opt/aws-eda-slurm-cluster/{{ cluster_name }}/bin/create_users_groups_json_deconfigure.sh
+    remote_src: true
+    force: true   # Has to be true or won't be copied when they are different.
+    owner: root
+    group: root
+    mode: 0700
+
+- name: Copy {{ slurm_config_dir }}/ansible/ to /opt/aws-eda-slurm-cluster/{{ cluster_name }}/ansible/
+  copy:
+    src: "{{ slurm_config_dir }}/ansible"
+    dest: /opt/aws-eda-slurm-cluster/{{ cluster_name }}/
+    remote_src: true
+    force: true   # Has to be true or won't be copied when they are different.
+    owner: root
+    group: root
+    directory_mode: 0700
+    mode: 0600

--- a/source/resources/playbooks/roles/ParallelClusterExternalLoginNodeConfigure/tasks/main.yml
+++ b/source/resources/playbooks/roles/ParallelClusterExternalLoginNodeConfigure/tasks/main.yml
@@ -151,3 +151,40 @@
     group: root
     mode: 0644
     force: yes
+
+- name: Create /opt/aws-eda-slurm-cluster/{{ cluster_name }}
+  file:
+    path: /opt/aws-eda-slurm-cluster/{{ cluster_name }}
+    owner: root
+    group: root
+    mode: 0700
+    state: directory
+
+- name: Create /opt/aws-eda-slurm-cluster/{{ cluster_name }}/bin
+  file:
+    path: /opt/aws-eda-slurm-cluster/{{ cluster_name }}/bin
+    owner: root
+    group: root
+    mode: 0700
+    state: directory
+
+- name: Copy {{ slurm_config_dir }}/bin/external_login_node_deconfigure.sh to /opt/aws-eda-slurm-cluster/{{ cluster_name }}/bin/
+  copy:
+    src: "{{ slurm_config_dir }}/bin/external_login_node_deconfigure.sh"
+    dest: /opt/aws-eda-slurm-cluster/{{ cluster_name }}/bin/external_login_node_deconfigure.sh
+    remote_src: true
+    force: true   # Has to be true or won't be copied when they are different.
+    owner: root
+    group: root
+    mode: 0700
+
+- name: Copy {{ slurm_config_dir }}/ansible/ to /opt/aws-eda-slurm-cluster/{{ cluster_name }}/ansible/
+  copy:
+    src: "{{ slurm_config_dir }}/ansible"
+    dest: /opt/aws-eda-slurm-cluster/{{ cluster_name }}/
+    remote_src: true
+    force: true   # Has to be true or won't be copied when they are different.
+    owner: root
+    group: root
+    directory_mode: 0700
+    mode: 0600

--- a/source/resources/playbooks/roles/ParallelClusterExternalLoginNodeDeconfigure/tasks/main.yml
+++ b/source/resources/playbooks/roles/ParallelClusterExternalLoginNodeDeconfigure/tasks/main.yml
@@ -10,27 +10,6 @@
     dest: /etc/profile.d/slurm_{{ cluster_name }}_modulefiles.sh
     state: absent
 
-- name: Unmount /opt/slurm/{{ cluster_name }}
-  shell: |
-    set -ex
-
-    # Handle case where cluster was already deleted so the mountpoint is hung
-    if ! timeout 1s /opt/slurm/{{ cluster_name }}; then
-        echo "Mount point is hung. Source has already been deleted."
-        umount -lf /opt/slurm/{{ cluster_name }}
-    fi
-    if ! mountpoint /opt/slurm/{{ cluster_name }}; then
-        echo "/opt/slurm/{{ cluster_name }} already unmounted."
-        exit 0
-    fi
-    umount /opt/slurm/{{ cluster_name }} || lsof /opt/slurm/{{ cluster_name }}
-  register: umount_results
-
-- name: Show umount results
-  debug:
-    msg: |
-      umount_results: {{ umount_results }}
-
 - name: Remove /opt/slurm/{{ cluster_name }} from /etc/fstab
   mount:
     path: /opt/slurm/{{ cluster_name }}

--- a/source/resources/playbooks/roles/install_slurm/tasks/main.yml
+++ b/source/resources/playbooks/roles/install_slurm/tasks/main.yml
@@ -114,7 +114,6 @@
       - libyaml-devel
       - lua-devel
       - lz4-devel
-      - mailx
       - make
       - man2html
       # munge is built from ParallelCluster version
@@ -133,6 +132,13 @@
       - rng-tools
       - rrdtool-devel
       - wget
+
+- name: Install slurm packages for not RHEL 9
+  when: not (rhel9 or rhel9clone)
+  yum:
+    state: present
+    name:
+      - mailx
 
 - name: Install hdf5-devel
   when: not(distribution == 'Amazon' and architecture == 'arm64') and not(rhel8 or rhel8clone or rhel9 or rhel9clone)
@@ -251,14 +257,6 @@
     mode: '0755'
   register: create_modulefile_dir_result
 
-- name: Fix modulefile permissions
-  when: create_modulefile_dir_result
-  shell:
-    cmd: |
-      set -ex
-
-      chmod -R 0755 {{ slurm_config_dir }}
-
 - name: Create slurm modulefile .template
   template:
     dest: "{{ modulefiles_base_dir }}/{{ distribution }}/{{ distribution_major_version }}/{{ architecture }}/{{ cluster_name }}/.template"
@@ -361,6 +359,7 @@
 
     # Create a symbolic link to the plugin at /usr/local/lib/slurm/
     rm -f /usr/local/lib/slurm/spank_pyxis.so
+    mkdir -p /usr/local/lib/slurm
     ln -s {{ slurm_os_dir }}/lib/slurm/spank_pyxis.so /usr/local/lib/slurm/
 
 - name: Set enroot and pyxis facts
@@ -370,7 +369,6 @@
     pyxis_runtime_dir:     '/run/pyxis'
 
 - name: Create {{ enroot_persistent_dir }}
-  when: primary_controller|bool
   file:
     path: "{{ enroot_persistent_dir }}"
     state: directory
@@ -379,7 +377,6 @@
     mode: 01777
 
 - name: Create {{ enroot_volatile_dir }}
-  when: primary_controller|bool
   file:
     path: "{{ enroot_volatile_dir }}"
     state: directory
@@ -388,7 +385,6 @@
     mode: 01777
 
 - name: Create {{ pyxis_runtime_dir }}
-  when: primary_controller|bool
   file:
     path: "{{ pyxis_runtime_dir }}"
     state: directory


### PR DESCRIPTION
Add comments to deconfigure scripts and during configuration make sure that the deconfigure scripts are installed on the root file system so that the deconfiguration can be done whether the cluster still exists or not.

Fix external login node configuration for rhel9

Resolves #300

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
