### PR TITLE
Add support for ParallelCluster 3.13.1

### DIFF
--- a/source/cdk/cdk_slurm_stack.py
+++ b/source/cdk/cdk_slurm_stack.py
@@ -99,6 +99,8 @@ class CdkSlurmStack(Stack):
 
         self.onprem_cidr = None
 
+        self.exostellar_vm_root_password_secret_arn = None
+
         self.principals_suffix = {
             "backup": f"backup.{Aws.URL_SUFFIX}",
             "cloudwatch": f"cloudwatch.{Aws.URL_SUFFIX}",
@@ -1192,8 +1194,6 @@ class CdkSlurmStack(Stack):
             exit(1)
 
     def get_exostellar_vm_root_password_secret_arn(self, config_key):
-        self.exostellar_vm_root_password_secret_arn = None
-
         self.exostellar_vm_root_password_secret = self.config['slurm'][config_key].get('VmRootPasswordSecret', '')
         if self.exostellar_vm_root_password_secret == '':
             return None

--- a/source/cdk/config_schema.py
+++ b/source/cdk/config_schema.py
@@ -102,6 +102,9 @@ logger.setLevel(logging.INFO)
 # 3.13.0:
 #     * Upgrade Slurm to 24.05.07
 #     * Upgrade to Python 3.12.8
+# 3.13.1:
+#     * Upgrade Slurm to 24.05.08
+#     * EFS utils to fix Rocky builds
 MIN_PARALLEL_CLUSTER_VERSION = parse_version('3.6.0')
 # Update source/resources/default_config.yml with latest version when this is updated.
 PARALLEL_CLUSTER_VERSIONS = [
@@ -121,6 +124,7 @@ PARALLEL_CLUSTER_VERSIONS = [
     '3.11.1',
     '3.12.0',
     '3.13.0',
+    '3.13.1',
 ]
 PARALLEL_CLUSTER_ENROOT_VERSIONS = {
     # This can be found on the head node by running 'yum info enroot'
@@ -128,6 +132,7 @@ PARALLEL_CLUSTER_ENROOT_VERSIONS = {
     '3.11.1':  '3.4.1', # confirmed
     '3.12.0':  '3.4.1', # confirmed
     '3.13.0':  '3.4.1', # confirmed
+    '3.13.1':  '3.4.1', # confirmed
 }
 PARALLEL_CLUSTER_PYXIS_VERSIONS = {
     # This can be found on the head node at /opt/parallelcluster/sources
@@ -135,6 +140,7 @@ PARALLEL_CLUSTER_PYXIS_VERSIONS = {
     '3.11.1':  '0.20.0', # confirmed
     '3.12.0':  '0.20.0', # confirmed
     '3.13.0':  '0.20.0', # confirmed
+    '3.13.1':  '0.20.0', # confirmed
 }
 PARALLEL_CLUSTER_MUNGE_VERSIONS = {
     # This can be found on the head node at /opt/parallelcluster/sources
@@ -155,6 +161,7 @@ PARALLEL_CLUSTER_MUNGE_VERSIONS = {
     '3.11.1':  '0.5.16', # confirmed
     '3.12.0':  '0.5.16', # confirmed
     '3.13.0':  '0.5.16', # confirmed
+    '3.13.1':  '0.5.16', # confirmed
 }
 PARALLEL_CLUSTER_PYTHON_VERSIONS = {
     # This can be found on the head node at /opt/parallelcluster/pyenv/versions
@@ -174,6 +181,7 @@ PARALLEL_CLUSTER_PYTHON_VERSIONS = {
     '3.11.1':  '3.9.20', # confirmed
     '3.12.0':  '3.9.20', # confirmed
     '3.13.0':  '3.12.0', # confirmed
+    '3.13.1':  '3.12.8', # confirmed
 }
 PARALLEL_CLUSTER_SLURM_VERSIONS = {
     # This can be found on the head node at /etc/chef/local-mode-cache/cache/
@@ -193,6 +201,7 @@ PARALLEL_CLUSTER_SLURM_VERSIONS = {
     '3.11.1':  '23.11.10', # confirmed
     '3.12.0':  '23.11.10', # confirmed
     '3.13.0':  '24.05.7',  # confirmed
+    '3.13.1':  '24.05.8',  # confirmed
 }
 PARALLEL_CLUSTER_PC_SLURM_VERSIONS = {
     # This can be found on the head node at /etc/chef/local-mode-cache/cache/
@@ -212,6 +221,7 @@ PARALLEL_CLUSTER_PC_SLURM_VERSIONS = {
     '3.11.1':  '23-11-10-1', # confirmed
     '3.12.0':  '23-11-10-1', # confirmed
     '3.13.0':  '24-05-7-1',  # confirmed
+    '3.13.1':  '24-05-8-1',  # confirmed
 }
 SLURM_REST_API_VERSIONS = {
     '23-02-2-1': '0.0.39',
@@ -224,6 +234,7 @@ SLURM_REST_API_VERSIONS = {
     '23-11-7-1': '0.0.39',
     '23-11-10-1': '0.0.39',
     '24-05-7-1': '0.0.39',
+    '24-05-8-1': '0.0.39',
 }
 
 def get_parallel_cluster_version(config):

--- a/source/resources/playbooks/roles/eda_tools/tasks/main.yml
+++ b/source/resources/playbooks/roles/eda_tools/tasks/main.yml
@@ -84,6 +84,28 @@
       - python3
       - python3-pip
 
+- name: Install python3.11
+  tags:
+    - python
+    - packages
+    - pip
+  yum:
+    state: present
+    name:
+      - python3.11
+      - python3.11-pip
+
+- name: Install python3.12
+  tags:
+    - python
+    - packages
+    - pip
+  yum:
+    state: present
+    name:
+      - python3.12
+      - python3.12-pip
+
 - name: Install packages required by python packages
   when: (rhel8 or rhel8clone or rhel9 or rhel9clone) and architecture == 'arm64'
   tags:


### PR DESCRIPTION
Updates efs-utils which was broken for Rocky Linux. Updates slurm version.

Add Python 3.11 and 3.12 to eda_tools packages.

Didn't push a couple of fixes for this.

Resolves #319

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
