### PR TITLE
Allow additional CustomActions scripts for head and compute nodes.

### DIFF
--- a/docs/deployment-prerequisites.md
+++ b/docs/deployment-prerequisites.md
@@ -582,3 +582,72 @@ slurm:
               PriorityTier: 1
               Nodes: sp-r7i-l-dy-sp-16-gb-1-cores-[1-100],sp-r7a-l-dy-sp-16-gb-2-cores-[1-20]
 ```
+
+### Configure Custom Head/Compute Node Scripts
+
+ParallelCluster support custom scripts for the head and compute nodes.
+
+#### Head Node Scripts
+
+Custom scripts for the head node are defined in the [CustomActions](https://docs.aws.amazon.com/parallelcluster/latest/ug/HeadNode-v3.html#HeadNode-v3-CustomActions) section of the ParallelCluster configuration.
+
+**NOTE:** The CustomActions cannot be updated once the cluster is created.
+
+```
+slurm:
+  ParallelClusterConfig:
+    ClusterConfig:
+      HeadNode:
+        CustomActions:
+          OnNodeStart:
+            Sequence:
+              - Script: string
+                Args:
+                  - string
+          OnNodeConfigured:
+            Sequence:
+              - Script: string
+                Args:
+                  - string
+          OnNodeUpdated:
+            Sequence:
+              - Script: string
+                Args:
+                  - string
+```
+
+When the cluster is created, the following two scripts are created that you can locally modify on the head node to customize the actions that are taken when the head node is updated.
+
+* /opt/slurm/config/bin/on_head_node_updated_prolog.sh
+* /opt/slurm/config/bin/on_head_node_updated_epilog.sh
+
+These scripts are called at the beginning and end of the `on_head_node_updated.sh` script.
+
+#### Compute Node Scripts
+
+If the following scripts exist they will be executed at the beginning and end of the `on_compute_node_configured.sh` script:
+
+* /opt/slurm/config/bin/on_compute_node_configured_custom_prolog.sh
+* /opt/slurm/config/bin/on_compute_node_configured_custom_epilog.sh
+
+You can also add additional scripts to all of the ParallelCluster compute nodes that will be prepended to the [CustomActions](https://docs.aws.amazon.com/parallelcluster/latest/ug/Scheduling-v3.html#Scheduling-v3-SlurmQueues-CustomActions) arrays in the ParallelCluster queues.
+
+**NOTE:** Updating these configuration parameters either requires the cluster to be stopped or the QueueUpdateStrategy to be set.
+
+The custom scripts are declared using the following configuration parameters.
+
+```
+slurm:
+  ParallelClusterConfig:
+    ComputeNodeCustomActions:
+      OnNodeStart:
+        Sequence:
+          - Script: string
+            Args:
+              - string
+      OnNodeConfigured:
+        Sequence:
+          - Script: string
+            Args:
+              - string
+```

--- a/source/cdk/cdk_slurm_stack.py
+++ b/source/cdk/cdk_slurm_stack.py
@@ -3382,7 +3382,7 @@ class CdkSlurmStack(Stack):
             },
             'CustomActions': {
                 'OnNodeStart': {
-                    'Sequence': [
+                    'Sequence': self.config['slurm']['ParallelClusterConfig'].get('ComputeNodeCustomActions', {}).get('OnNodeStart', {}).get('Sequence', []) + [
                         {
                             'Script': self.custom_action_s3_urls['config/bin/on_compute_node_start.sh'],
                             'Args': []
@@ -3390,7 +3390,7 @@ class CdkSlurmStack(Stack):
                     ]
                 },
                 'OnNodeConfigured': {
-                    'Sequence': [
+                    'Sequence': self.config['slurm']['ParallelClusterConfig'].get('ComputeNodeCustomActions', {}).get('OnNodeConfigured', {}).get('Sequence', []) + [
                         {
                             'Script': self.custom_action_s3_urls['config/bin/on_compute_node_configured.sh'],
                             'Args': []

--- a/source/cdk/config_schema.py
+++ b/source/cdk/config_schema.py
@@ -2332,6 +2332,24 @@ def get_config_schema(config):
                             },
                         }
                     ]
+                },
+                Optional('ComputeNodeCustomActions'): {
+                    Optional('OnNodeStart'): {
+                        'Sequence': [
+                            {
+                                'Script': str,
+                                'Args': [str]
+                            }
+                        ]
+                    },
+                    Optional('OnNodeConfigured'): {
+                        'Sequence': [
+                            {
+                                'Script': str,
+                                'Args': [str]
+                            }
+                        ]
+                    }
                 }
             },
             #

--- a/source/resources/parallel-cluster/config/bin/on_compute_node_start.sh
+++ b/source/resources/parallel-cluster/config/bin/on_compute_node_start.sh
@@ -30,6 +30,10 @@ trap on_exit EXIT
 
 # /opt/slurm isn't mounted yet.
 
+if [ -e $config_bin_dir/on_compute_node_start_custom_prolog.sh ]; then
+    $config_bin_dir/on_compute_node_start_custom_prolog.sh
+fi
+
 # Configure pyxis and enroot
 
 # Configure Enroot
@@ -48,6 +52,10 @@ PYXIS_RUNTIME_DIR="/run/pyxis"
 
 sudo mkdir -p $PYXIS_RUNTIME_DIR
 sudo chmod 1777 $PYXIS_RUNTIME_DIR
+
+if [ -e $config_bin_dir/on_compute_node_start_custom_epilog.sh ]; then
+    $config_bin_dir/on_compute_node_start_custom_epilog.sh
+fi
 
 echo "$(date): Finished ${script_name}"
 

--- a/source/resources/parallel-cluster/config/bin/on_head_node_updated.sh
+++ b/source/resources/parallel-cluster/config/bin/on_head_node_updated.sh
@@ -47,7 +47,15 @@ fi
 
 export PATH=/usr/sbin:$PATH
 
+if [[ -e $config_bin_dir/on_head_node_updated_custom_prolog.sh ]]; then
+    $config_bin_dir/on_head_node_updated_custom_prolog.sh
+fi
+
 $config_bin_dir/on_head_node_configured.sh
+
+if [[ -e $config_bin_dir/on_head_node_updated_custom_epilog.sh ]]; then
+    $config_bin_dir/on_head_node_updated_custom_epilog.sh
+fi
 
 echo "$(date): Finished ${script_name}"
 

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/files/opt/slurm/config/bin/on_compute_node_configured_custom_epilog.sh
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/files/opt/slurm/config/bin/on_compute_node_configured_custom_epilog.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -x
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# This script gets called at the end of /opt/slurm/config/bin/on_compute_node_configured.sh.
+# The user can update this script so that they can do additional actions when the compute node is configured.
+
+set -x
+set -e
+
+script_name=on_compute_node_configured_custom_epilog.sh
+
+exec 1> >(logger -s -t ${script_name}) 2>&1
+
+echo "$(date): Started ${script_name}"
+
+# Add your code after this line
+
+echo "$(date): Finished ${script_name}"
+
+exit 0

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/files/opt/slurm/config/bin/on_compute_node_configured_custom_prolog.sh
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/files/opt/slurm/config/bin/on_compute_node_configured_custom_prolog.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -x
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# This script gets called at the beginning of /opt/slurm/config/bin/on_compute_node_configured.sh.
+# The user can update this script so that they can do additional actions when the compute node is configured.
+
+set -x
+set -e
+
+script_name=on_compute_node_configured_custom_prolog.sh
+
+exec 1> >(logger -s -t ${script_name}) 2>&1
+
+echo "$(date): Started ${script_name}"
+
+# Add your code after this line
+
+echo "$(date): Finished ${script_name}"
+
+exit 0

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/files/opt/slurm/config/bin/on_compute_node_start_custom_epilog.sh
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/files/opt/slurm/config/bin/on_compute_node_start_custom_epilog.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -x
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# This script gets called at the end of /opt/slurm/config/bin/on_compute_node_start.sh.
+# The user can update this script so that they can do additional actions when the compute node is started.
+# Be aware that /opt/slurm will not be mounted until after the compute node is started.
+
+set -x
+set -e
+
+script_name=on_compute_node_start_custom_epilog.sh
+
+exec 1> >(logger -s -t ${script_name}) 2>&1
+
+echo "$(date): Started ${script_name}"
+
+# Add your code after this line
+
+echo "$(date): Finished ${script_name}"
+
+exit 0

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/files/opt/slurm/config/bin/on_compute_node_start_custom_prolog.sh
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/files/opt/slurm/config/bin/on_compute_node_start_custom_prolog.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -x
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# This script gets called at the beginning of /opt/slurm/config/bin/on_compute_node_start.sh.
+# The user can update this script so that they can do additional actions when the compute node is started.
+# Be aware that /opt/slurm will not be mounted until after the compute node is started.
+
+set -x
+set -e
+
+script_name=on_compute_node_start_custom_prolog.sh
+
+exec 1> >(logger -s -t ${script_name}) 2>&1
+
+echo "$(date): Started ${script_name}"
+
+# Add your code after this line
+
+echo "$(date): Finished ${script_name}"
+
+exit 0

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/files/opt/slurm/config/bin/on_head_node_updated_custom_epilog.sh
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/files/opt/slurm/config/bin/on_head_node_updated_custom_epilog.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -x
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# This script gets called at the end of /opt/slurm/config/bin/on_head_node_updated.sh.
+# The user can update this script so that they can do additional actions when the head node is updated.
+
+set -x
+set -e
+
+script_name=on_head_node_updated_custom_epilog.sh
+
+exec 1> >(logger -s -t ${script_name}) 2>&1
+
+echo "$(date): Started ${script_name}"
+
+# Add your code after this line
+
+echo "$(date): Finished ${script_name}"
+
+exit 0

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/files/opt/slurm/config/bin/on_head_node_updated_custom_prolog.sh
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/files/opt/slurm/config/bin/on_head_node_updated_custom_prolog.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -x
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# This script gets called at the beginning of /opt/slurm/config/bin/on_head_node_updated.sh.
+# The user can update this script so that they can do additional actions when the head node is updated.
+
+set -x
+set -e
+
+script_name=on_head_node_updated_custom_prolog.sh
+
+exec 1> >(logger -s -t ${script_name}) 2>&1
+
+echo "$(date): Started ${script_name}"
+
+# Add your code after this line
+
+echo "$(date): Finished ${script_name}"
+
+exit 0

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/config-scripts.yml
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/config-scripts.yml
@@ -1,0 +1,71 @@
+---
+
+- name: Create /opt/slurm/config
+  ansible.builtin.file:
+    path: "/opt/slurm/config"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Create /opt/slurm/config/bin
+  ansible.builtin.file:
+    path: "/opt/slurm/config/bin"
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Create /opt/slurm/config/bin/on_head_node_updated_custom_prolog.sh
+  ansible.builtin.copy:
+    dest: "/opt/slurm/config/bin/on_head_node_updated_custom_prolog.sh"
+    src:   "opt/slurm/config/bin/on_head_node_updated_custom_prolog.sh"
+    owner: root
+    group: root
+    mode: '0700'
+    force: false
+
+- name: Create /opt/slurm/config/bin/on_head_node_updated_custom_epilog.sh
+  ansible.builtin.copy:
+    dest: "/opt/slurm/config/bin/on_head_node_updated_custom_epilog.sh"
+    src:   "opt/slurm/config/bin/on_head_node_updated_custom_epilog.sh"
+    owner: root
+    group: root
+    mode: '0700'
+    force: false
+
+- name: Create /opt/slurm/config/bin/on_compute_node_start_custom_prolog.sh
+  ansible.builtin.copy:
+    dest: "/opt/slurm/config/bin/on_compute_node_start_custom_prolog.sh"
+    src:   "opt/slurm/config/bin/on_compute_node_start_custom_prolog.sh"
+    owner: root
+    group: root
+    mode: '0700'
+    force: false
+
+- name: Create /opt/slurm/config/bin/on_compute_node_start_custom_epilog.sh
+  ansible.builtin.copy:
+    dest: "/opt/slurm/config/bin/on_compute_node_start_custom_epilog.sh"
+    src:   "opt/slurm/config/bin/on_compute_node_start_custom_epilog.sh"
+    owner: root
+    group: root
+    mode: '0700'
+    force: false
+
+- name: Create /opt/slurm/config/bin/on_compute_node_configured_custom_prolog.sh
+  ansible.builtin.copy:
+    dest: "/opt/slurm/config/bin/on_compute_node_configured_custom_prolog.sh"
+    src:   "opt/slurm/config/bin/on_compute_node_configured_custom_prolog.sh"
+    owner: root
+    group: root
+    mode: '0700'
+    force: false
+
+- name: Create /opt/slurm/config/bin/on_compute_node_configured_custom_epilog.sh
+  ansible.builtin.copy:
+    dest: "/opt/slurm/config/bin/on_compute_node_configured_custom_epilog.sh"
+    src:   "opt/slurm/config/bin/on_compute_node_configured_custom_epilog.sh"
+    owner: root
+    group: root
+    mode: '0700'
+    force: false

--- a/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/main.yml
+++ b/source/resources/playbooks/roles/ParallelClusterHeadNode/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 
+- { include_tasks: config-scripts.yml }
 - { include_tasks: config-users-groups.yml,    tags: users-groups }
 - { include_tasks: config-high-throughput.yml, tags: high-throughput }
 - { include_tasks: config-external-login-node-access.yml, tags: external-login-node }


### PR DESCRIPTION
For the head node add 2 scripts that can be edited on the head node that will be run when the head node is updated.

Do the same for the OnNodeStart and OnNodeConfigured custom actions for compute nodes.

Add additional parameter to provide additional compute node CustomActions in the ParallelCluster config.

Resolves #320

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
